### PR TITLE
[GLES2] allow glShaderSource to deal with negative length items

### DIFF
--- a/src/gl/shader.c
+++ b/src/gl/shader.c
@@ -130,13 +130,17 @@ void gl4es_glShaderSource(GLuint shader, GLsizei count, const GLchar * const *st
     CHECK_SHADER(void, shader)
     // get the size of the shader sources and than concatenate in a single string
     int l = 0;
-    for (int i=0; i<count; i++) l+=(length)?length[i]:strlen(string[i]);
+    for (int i=0; i<count; i++) l+=(length && length[i] >= 0)?length[i]:strlen(string[i]);
     if(glshader->source) free(glshader->source);
     glshader->source = malloc(l+1);
     memset(glshader->source, 0, l+1);
     if(length) {
-        for (int i=0; i<count; i++)
-            strncat(glshader->source, string[i], length[i]);
+        for (int i=0; i<count; i++) {
+            if(length[i] >= 0)
+                strncat(glshader->source, string[i], length[i]);
+            else
+                strcat(glshader->source, string[i]);
+        }
     } else {
         for (int i=0; i<count; i++)
             strcat(glshader->source, string[i]);


### PR DESCRIPTION
The glShaderSource function should allow the length array passed to it
to contain negative values. In this case the length value should not be
used, instead the string with the same index should be considered as a
NULL-terminated string.

The game Taisei calls glShaderSource in this way (all length values are
-1). This commit makes this game running well with gl4es and Mesa GLES2
driver.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>