### PR TITLE
fix 64-bit pointer support for widthalign macro

### DIFF
--- a/src/gl/pixel.h
+++ b/src/gl/pixel.h
@@ -12,7 +12,7 @@ typedef struct {
     GLfloat r, g, b, a;
 } pixel_t;
 
-#define widthalign(width, align) (((width)+(align-1))&(~(align-1)))
+#define widthalign(width, align) ((((uintptr_t)(width))+((uintptr_t)(align)-1))&(~((uintptr_t)(align)-1)))
 
 bool pixel_convert(const GLvoid *src, GLvoid **dst,
                    GLuint width, GLuint height,


### PR DESCRIPTION
The widthalign macro fails to work on 64-bit platforms, as the width
might be considered as 32-bit (unsigned )int instead of 64-bit (u)intptr_t.

Fix this by force convert all reference of the parameters of the macro
to uintptr_t.

This fixes texture loading on x86_64 platform.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>