### PR TITLE
[GLES2] fix the place of #extension when GL_EXT_frag_depth is present

### DIFF
--- a/src/gl/shaderconv.c
+++ b/src/gl/shaderconv.c
@@ -260,10 +260,11 @@ char* ConvertShader(const char* pBuffer, int isVertex)
   int headline = 2;
   // check if gl_FragDepth is used
   int fragdepth = (strstr(pBuffer, "gl_FragDepth"))?1:0;
-  const char* GLESUseFragDepth = "#extension GL_EXT_frag_depth : enable";
-  const char* GLESFakeFragDepth = "mediump float fakeFragDepth = 0.0;";
+  const char* GLESUseFragDepth = "#extension GL_EXT_frag_depth : enable\n";
+  const char* GLESFakeFragDepth = "mediump float fakeFragDepth = 0.0;\n";
   if (fragdepth) {
-    strcat(Tmp, hardext.fragdepth?GLESUseFragDepth:GLESFakeFragDepth);
+    /* If #extension is used, it should be placed before the second line of the header. */
+    InplaceInsert(GetLine(Tmp, headline-1), hardext.fragdepth?GLESUseFragDepth:GLESFakeFragDepth);
     headline++;
   }
   strcat(Tmp, newptr);


### PR DESCRIPTION
When GL_EXT_frag_depth is present, the shader converter will try to add
a #extension sentence to enable it. However, it's wrongly placed after a
line of ordinary definition in the header, which makes the converted shader
grammarly error.

Fix this by insert the #extension sentence before the definition.

The sentences of GL_EXT_frag_depth used to lack a newline, and it's also
added in this commit.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>