### PR TITLE
Perl 5.26 OpenGL module on Ubuntu is missing symbols

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ SET(GL_SRC
     gl/shaderconv.c
     gl/stack.c
     gl/string_utils.c
+    gl/stubs.c
     gl/texenv.c
     gl/texgen.c
     gl/texture.c

--- a/src/gl/drawing.c
+++ b/src/gl/drawing.c
@@ -658,6 +658,7 @@ void gl4es_glDrawArrays(GLenum mode, GLint first, GLsizei count) {
     }
 }
 void glDrawArrays(GLenum mode, GLint first, GLsizei count) AliasExport("gl4es_glDrawArrays");
+void glDrawArraysEXT(GLenum mode, GLint first, GLsizei count) AliasExport("gl4es_glDrawArrays");
 
 //#define ACTIVE_MULTIDRAW
 void gl4es_glMultiDrawArrays(GLenum mode, const GLint *first, const GLsizei *count, GLsizei primcount)

--- a/src/gl/gl.c
+++ b/src/gl/gl.c
@@ -988,6 +988,7 @@ void gl4es_glArrayElement(GLint i) {
     }
 }
 void glArrayElement(GLint i) AliasExport("gl4es_glArrayElement");
+void glArrayElementEXT(GLint i) AliasExport("gl4es_glArrayElement");
 
 // TODO: between a lock and unlock, I can assume the array pointers are unchanged
 // so I can build a renderlist_t on the first call and hold onto it

--- a/src/gl/pointsprite.c
+++ b/src/gl/pointsprite.c
@@ -22,6 +22,7 @@ void gl4es_glPointParameterf(GLenum pname, GLfloat param) {
     gl4es_glPointParameterfv(pname, &param);
 }
 void glPointParameterf(GLenum pname, GLfloat param) AliasExport("gl4es_glPointParameterf");
+void glPointParameterfARB(GLenum pname, GLfloat param) AliasExport("gl4es_glPointParameterf");
 
 void gl4es_glPointParameterfv(GLenum pname, const GLfloat * params)
 {
@@ -106,6 +107,7 @@ void gl4es_glPointParameterfv(GLenum pname, const GLfloat * params)
     gles_glPointParameterfv(pname, params);
 }
 void glPointParameterfv(GLenum pname, const GLfloat * params) AliasExport("gl4es_glPointParameterfv");
+void glPointParameterfvARB(GLenum pname, const GLfloat * params) AliasExport("gl4es_glPointParameterfv");
 
 void gl4es_glPointSize(GLfloat size) {
     if(size<=0.0f) {

--- a/src/gl/stubs.c
+++ b/src/gl/stubs.c
@@ -1,0 +1,29 @@
+#include "gl.h"
+
+#define GLAPI __attribute__((visibility("default")))
+#define APIENTRY
+#define STUB errorShim(GL_INVALID_VALUE);
+
+GLAPI void APIENTRY glDrawBuffers (GLsizei n, const GLenum *bufs){STUB}
+GLAPI void APIENTRY glDrawBuffersARB (GLsizei n, const GLenum *bufs){STUB}
+GLAPI void APIENTRY glClampColorARB (GLenum target, GLenum clamp){STUB}
+
+GLAPI void APIENTRY glProgramStringARB (GLenum target, GLenum format, GLsizei len, const GLvoid *string){STUB}
+GLAPI void APIENTRY glBindProgramARB (GLenum target, GLuint program){STUB}
+GLAPI void APIENTRY glDeleteProgramsARB (GLsizei n, const GLuint *programs){STUB}
+GLAPI void APIENTRY glGenProgramsARB (GLsizei n, GLuint *programs){STUB}
+GLAPI void APIENTRY glProgramEnvParameter4dARB (GLenum target, GLuint index, GLdouble x, GLdouble y, GLdouble z, GLdouble w){STUB}
+GLAPI void APIENTRY glProgramEnvParameter4dvARB (GLenum target, GLuint index, const GLdouble *params){STUB}
+GLAPI void APIENTRY glProgramEnvParameter4fARB (GLenum target, GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w){STUB}
+GLAPI void APIENTRY glProgramEnvParameter4fvARB (GLenum target, GLuint index, const GLfloat *params){STUB}
+GLAPI void APIENTRY glProgramLocalParameter4dARB (GLenum target, GLuint index, GLdouble x, GLdouble y, GLdouble z, GLdouble w){STUB}
+GLAPI void APIENTRY glProgramLocalParameter4dvARB (GLenum target, GLuint index, const GLdouble *params){STUB}
+GLAPI void APIENTRY glProgramLocalParameter4fARB (GLenum target, GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w){STUB}
+GLAPI void APIENTRY glProgramLocalParameter4fvARB (GLenum target, GLuint index, const GLfloat *params){STUB}
+GLAPI void APIENTRY glGetProgramEnvParameterdvARB (GLenum target, GLuint index, GLdouble *params){STUB}
+GLAPI void APIENTRY glGetProgramEnvParameterfvARB (GLenum target, GLuint index, GLfloat *params){STUB}
+GLAPI void APIENTRY glGetProgramLocalParameterdvARB (GLenum target, GLuint index, GLdouble *params){STUB}
+GLAPI void APIENTRY glGetProgramLocalParameterfvARB (GLenum target, GLuint index, GLfloat *params){STUB}
+GLAPI void APIENTRY glGetProgramivARB (GLenum target, GLenum pname, GLint *params){STUB}
+GLAPI void APIENTRY glGetProgramStringARB (GLenum target, GLenum pname, GLvoid *string){STUB}
+GLAPI GLboolean APIENTRY glIsProgramARB (GLuint program){STUB return 0;}

--- a/src/gl/texture.c
+++ b/src/gl/texture.c
@@ -2683,6 +2683,7 @@ void realize_textures() {
 void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid *data) AliasExport("gl4es_glTexImage2D");
 void glTexImage1D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLint border, GLenum format, GLenum type, const GLvoid *data) AliasExport("gl4es_glTexImage1D");
 void glTexImage3D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const GLvoid *data) AliasExport("gl4es_glTexImage3D");
+void glTexImage3DEXT(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const GLvoid *data) AliasExport("gl4es_glTexImage3D");
 void glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid *data) AliasExport("gl4es_glTexSubImage2D");
 void glTexSubImage1D(GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format, GLenum type, const GLvoid *data) AliasExport("gl4es_glTexSubImage1D");
 void glTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,  GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const GLvoid *data) AliasExport("gl4es_glTexSubImage3D");

--- a/src/gl/wrap/gl.c
+++ b/src/gl/wrap/gl.c
@@ -874,8 +874,10 @@ THUNK(ui, GLuint)
 THUNK(us, GLushort)
 #undef THUNK
 
+void glMultiTexCoord1fARB(GLenum target, GLfloat s, GLfloat t) AliasExport("gl4es_glMultiTexCoord1f");
 void glMultiTexCoord2fARB(GLenum target, GLfloat s, GLfloat t) AliasExport("gl4es_glMultiTexCoord2f");
 void glMultiTexCoord3fARB(GLenum target, GLfloat s, GLfloat t, GLfloat r) AliasExport("gl4es_glMultiTexCoord3f");
+void glMultiTexCoord1fvARB(GLenum target, GLfloat *t) AliasExport("gl4es_glMultiTexCoord1fv");
 //void glMultiTexCoord2fvARB(GLenum target, GLfloat *t) AliasExport("gl4es_glMultiTexCoord2fv");
 void glMultiTexCoord3fvARB(GLenum target, GLfloat *t) AliasExport("gl4es_glMultiTexCoord3fv");
 //void glMultiTexCoord4fvARB(GLenum target, GLfloat *t) AliasExport("gl4es_glMultiTexCoord4fv");

--- a/src/gl/wrap/gles.c
+++ b/src/gl/wrap/gles.c
@@ -538,6 +538,7 @@ void gl4es_glDrawArrays(GLenum mode, GLint first, GLsizei count) {
     gles_glDrawArrays(mode, first, count);
 }
 void glDrawArrays(GLenum mode, GLint first, GLsizei count) __attribute__((alias("gl4es_glDrawArrays"))) __attribute__((visibility("default")));
+void glDrawArraysEXT(GLenum mode, GLint first, GLsizei count) __attribute__((alias("gl4es_glDrawArrays"))) __attribute__((visibility("default")));
 #endif
 #ifndef skip_glDrawElements
 void gl4es_glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid * indices) {
@@ -1738,6 +1739,7 @@ void gl4es_glSampleCoverage(GLclampf value, GLboolean invert) {
     gles_glSampleCoverage(value, invert);
 }
 void glSampleCoverage(GLclampf value, GLboolean invert) __attribute__((alias("gl4es_glSampleCoverage"))) __attribute__((visibility("default")));
+void glSampleCoverageARB(GLclampf value, GLboolean invert) __attribute__((alias("gl4es_glSampleCoverage"))) __attribute__((visibility("default")));
 #endif
 #ifndef skip_glSampleCoveragex
 void gl4es_glSampleCoveragex(GLclampx value, GLboolean invert) {


### PR DESCRIPTION
Something changed on Ubuntu, where the OpenGL module used to work just fine with gl4es (tested with 5.22). With current Ubuntu Perl 5.26, the OpenGL module links to additional symbols directly, without dynamic lookup. This results in "undefined symbol" errors and program abort.

Most annoyingly, the obsolete GL_ARB_vertex_program extension is among these new symbols. New file src/gl/stubs.c implements empty stubs that set a GL error.

A couple of additional symbols use their ...ARB/...EXT name, where just that alias is missing, so I added those in the corresponding files.