### PR TITLE
Let DEFAULT_ES option can be supported in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOEGL)
 endif()
 
 #DEFAULT_ES=2
-if(${DEFAULT_ES} STREQUAL 2)
+if(${DEFAULT_ES} STREQUAL "2")
     add_definitions(-DDEFAULT_ES=2)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,11 @@ if(NOEGL)
     add_definitions(-DNOX11)
 endif()
 
+#DEFAULT_ES=2
+if(${DEFAULT_ES} STREQUAL 2)
+    add_definitions(-DDEFAULT_ES=2)
+endif()
+
 link_directories(${CMAKE_BINARY_DIR}/lib)
 add_definitions(-g -std=gnu99 -funwind-tables -O3 -fvisibility=hidden)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOEGL)
 endif()
 
 #DEFAULT_ES=2
-if(${DEFAULT_ES} STREQUAL "2")
+if("${DEFAULT_ES}" STREQUAL "2")
     add_definitions(-DDEFAULT_ES=2)
 endif()
 


### PR DESCRIPTION
Added one option in the CMake, let gl4es can set default LIBGL_ES backend as GLES 2.0.

`cmake . -DDEFAULT_ES=2; make GL`

