### PR TITLE
Added CTest support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ CMakeCache.txt
 cmake_install.cmake
 spec/yml/gles-1.1-full.yml
 /build/
+/tests/*.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 #NOX11
 if(NOX11)
-	add_definitions(-DNOX11)
+    add_definitions(-DNOX11)
 endif()
 
 #NOEGL
@@ -116,3 +116,85 @@ add_definitions(-std=gnu99 -funwind-tables -fvisibility=hidden)
 
 include_directories(include)
 add_subdirectory(src)
+
+enable_testing()
+
+macro(create_test test_name test_filename calls_count tolerance)
+    if (${ARGC} EQUAL 5)
+        add_test(${test_name}
+            ${CMAKE_COMMAND}
+            -D LIBRARY_FOLDER=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+            -D TESTS_DIRECTORY=${CMAKE_SOURCE_DIR}/tests
+            -D TEST_FILENAME=${test_filename}
+            -D CALLS=${calls_count}
+            -D TOLERANCE=${tolerance}
+            -D EXTRACT_RANGE=${ARGV4}
+            -P ${CMAKE_SOURCE_DIR}/test.cmake)
+    elseif (${ARGC} EQUAL 6)
+        if (${ARGV4} STREQUAL "NOEXTRACT_RANGE")
+            add_test(${test_name}
+                ${CMAKE_COMMAND}
+                -D LIBRARY_FOLDER=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+                -D TESTS_DIRECTORY=${CMAKE_SOURCE_DIR}/tests
+                -D TEST_FILENAME=${test_filename}
+                -D CALLS=${calls_count}
+                -D TOLERANCE_GLES1=${tolerance}
+                -D TOLERANCE_GLES2=${ARGV5}
+                -P ${CMAKE_SOURCE_DIR}/test.cmake)
+        else (${ARGV4} STREQUAL "NOEXTRACT_RANGE")
+        add_test(${test_name}
+            ${CMAKE_COMMAND}
+            -D LIBRARY_FOLDER=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+            -D TESTS_DIRECTORY=${CMAKE_SOURCE_DIR}/tests
+            -D TEST_FILENAME=${test_filename}
+            -D CALLS=${calls_count}
+            -D TOLERANCE_GLES1=${tolerance}
+            -D TOLERANCE_GLES2=${ARGV5}
+            -D EXTRACT_RANGE=${ARGV4}
+            -P ${CMAKE_SOURCE_DIR}/test.cmake)
+        endif (${ARGV4} STREQUAL "NOEXTRACT_RANGE")
+    else (${ARGC} EQUAL 5)
+        add_test(${test_name}
+            ${CMAKE_COMMAND}
+            -D LIBRARY_FOLDER=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+            -D TESTS_DIRECTORY=${CMAKE_SOURCE_DIR}/tests
+            -D TEST_FILENAME=${test_filename}
+            -D CALLS=${calls_count}
+            -D TOLERANCE=${tolerance}
+            -P ${CMAKE_SOURCE_DIR}/test.cmake)
+    endif (${ARGC} EQUAL 5)
+endmacro(create_test)
+
+macro(create_test_GLES test_name GLES test_filename calls_count tolerance)
+    if (${ARGC} EQUAL 5)
+        add_test(${test_name}_GLES${GLES}
+            ${CMAKE_COMMAND}
+            -D LIBRARY_FOLDER=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+            -D TESTS_DIRECTORY=${CMAKE_SOURCE_DIR}/tests
+            -D TEST_FILENAME=${test_filename}
+            -D CALLS=${calls_count}
+            -D TOLERANCE=${tolerance}
+            -D EXTRACT_RANGE=${ARGV4}
+            -D GLES_FORCED=${GLES}
+            -P ${CMAKE_SOURCE_DIR}/test.cmake)
+    else (${ARGC} EQUAL 5)
+        add_test(${test_name}_GLES${GLES}
+            ${CMAKE_COMMAND}
+            -D LIBRARY_FOLDER=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+            -D TESTS_DIRECTORY=${CMAKE_SOURCE_DIR}/tests
+            -D TEST_FILENAME=${test_filename}
+            -D CALLS=${calls_count}
+            -D TOLERANCE=${tolerance}
+            -D GLES_FORCED=${GLES}
+            -P ${CMAKE_SOURCE_DIR}/test.cmake)
+    endif (${ARGC} EQUAL 5)
+endmacro(create_test_GLES)
+
+create_test(GLXgears glxgears "0000008203" 25 "NOEXTRACT_RANGE" 700)
+create_test(StuntCarRacer stuntcarracer "0000118817" 20 "638x478+1+1")
+create_test(Neverball neverball "0000078750" 20 "798x478+1+1" 200)
+create_test(FoobillardPlus foobillardplus "0000014748" 20 "798x478+1+1" 60)
+create_test(PointSprite pointsprite "0000248810" 20)
+
+create_test_GLES(OpenRA 2 openra "0000031249" 20 "638x478+1+1")
+create_test_GLES(GLSL_lighting 2 glsl_lighting "0000505393" 20)

--- a/test.cmake
+++ b/test.cmake
@@ -1,0 +1,63 @@
+# Check if all required arguments are provided
+macro(argument_required argument failstring)
+	if (NOT ${argument})
+		message(FATAL_ERROR ${failstring})
+	endif (NOT ${argument})
+endmacro(argument_required)
+
+argument_required(LIBRARY_FOLDER "All tests require to have a library output folder.")
+argument_required(TESTS_DIRECTORY "All tests require to have a test folder.")
+argument_required(TEST_FILENAME "All tests require a trace filename to be reprinted.")
+argument_required(CALLS "All tests require a call count.")
+
+# Enable different GLES version tests
+if (GLES_FORCED)
+	set(GLES${GLES_FORCED}_ENABLED ON)
+else (GLES_FORCED)
+	set(GLES1_ENABLED ON)
+	set(GLES2_ENABLED ON)
+endif (GLES_FORCED)
+
+# Special case fo pixels tolerance
+if (TOLERANCE)
+	set(TOLERANCE_GLES1 ${TOLERANCE})
+	set(TOLERANCE_GLES2 ${TOLERANCE})
+endif (TOLERANCE)
+
+# Use the built library
+set(ENV{LD_LIBRARY_PATH} ${LIBRARY_FOLDER}:$ENV{LD_LIBRARY_PATH})
+
+macro(run_test GLES toler)
+	set(ENV{LIBGL_ES} ${GLES})
+
+	message(STATUS "Starting test in GLES $ENV{LIBGL_ES}...")
+	execute_process(
+		COMMAND ${TESTS_DIRECTORY}/test.sh
+		 ${TEST_FILENAME}
+		 ${CALLS}
+		 ${toler}
+		 ${EXTRACT_RANGE}
+		ERROR_VARIABLE TEST_ERROR
+		OUTPUT_VARIABLE TEST_OUTPUT
+		WORKING_DIRECTORY ${TESTS_DIRECTORY}
+	)
+	message(STATUS "Ran test.\nError: ${TEST_ERROR}\nOutput: ${TEST_OUTPUT}")
+	
+	if (TEST_ERROR)
+		message(FATAL_ERROR "Test failed while using GLES $ENV{LIBGL_ES}.\n${TEST_ERROR}")
+	endif (TEST_ERROR)
+endmacro(run_test)
+
+# Run the test using GLES 1, if not disabled
+if (GLES1_ENABLED)
+	argument_required(TOLERANCE_GLES1 "All tests require a pixel tolerance for GLES 1.")
+	run_test(1 ${TOLERANCE_GLES1})
+endif (GLES1_ENABLED)
+
+# Run the test using GLES 2, if not disabled
+if (GLES2_ENABLED)
+	argument_required(TOLERANCE_GLES2 "All tests require a pixel tolerance for GLES 2.")
+	run_test(2 ${TOLERANCE_GLES2})
+endif (GLES2_ENABLED)
+
+message(STATUS "Success.")

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# WARNING: do not execute this file unless you are aware of what you're doing.
+# This file is meant to be executed by ctest.
+
+export LIBGL_FB=3
+export LIBGL_SILENTSTUB=1
+export LIBGL_NOBANNER=1
+
+tar xf ../traces/$1.tgz
+apitrace dump-images --calls="$2" $1.trace >/dev/null
+rm $1.trace
+
+if [[ -f $1.$2.png ]]
+then
+	mv $1.$2.png $1.$2.$LIBGL_ES.png
+
+	EXTRACT=""
+	if [[ ! -z "$4" ]]
+	then
+		EXTRACT="-extract $4"
+	fi
+	result=$(compare -metric AE -fuzz 20% $EXTRACT ../refs/$1.$2.png $1.$2.$LIBGL_ES.png diff_$1_GLES$LIBGL_ES.png 2>&1)
+
+	if [[ ! "$result" -lt "$3" ]]
+	then
+		echo "Error: $result pixels diff" 1>&2
+		exit 1
+	fi
+
+	[[ -e diff_$1_GLES$LIBGL_ES.png ]] && rm diff_$1_GLES$LIBGL_ES.png
+	[[ -e $1.$2.$LIBGL_ES.png ]] && rm $1.$2.$LIBGL_ES.png
+fi
+
+exit 0


### PR DESCRIPTION
This PR features multiple automated test for CTest (it is the same as running `tests/tests.sh`, but doesn't stop when a test failed, reduces outputed text and outputs less files) and ignore all PNG inside the `tests/` root folder.