### PR TITLE
Fix bufferGetParameteriv return type

### DIFF
--- a/src/gl/buffers.c
+++ b/src/gl/buffers.c
@@ -292,7 +292,7 @@ GLboolean gl4es_glIsBuffer(GLuint buffer) {
 }
 
 
-static void* bufferGetParameteriv(glbuffer_t* buff, GLenum value, GLint * data) {
+static void bufferGetParameteriv(glbuffer_t* buff, GLenum value, GLint * data) {
 	noerrorShim();
 	switch (value) {
 		case GL_BUFFER_ACCESS:


### PR DESCRIPTION
`void*` can be a typo: `bufferGetParameteriv()` doesn't return any value and its
return value is not used anywhere else.