### PR TITLE
Fix cross3 return type

### DIFF
--- a/src/gl/matvec.c
+++ b/src/gl/matvec.c
@@ -25,7 +25,7 @@ float FASTMATH dot4(const float *a, const float *b) {
 #endif
 }
 
-float cross3(const float *a, const float *b, float* c) {
+void cross3(const float *a, const float *b, float* c) {
     //TODO Neonize? Cross product doesn't seems NEON friendly, and this is not much used.
     c[0] = a[1]*b[2] - a[2]*b[1];
     c[1] = a[3]*b[0] - a[0]*b[3];

--- a/src/gl/matvec.h
+++ b/src/gl/matvec.h
@@ -6,7 +6,7 @@
 
 float dot(const float *a, const float *b) FASTMATH;
 float dot4(const float *a, const float *b) FASTMATH;
-float cross3(const float *a, const float *b, float* c) FASTMATH;
+void cross3(const float *a, const float *b, float* c) FASTMATH;
 void matrix_vector(const float *a, const float *b, float *c);
 void vector_matrix(const float *a, const float *b, float *c);
 void vector3_matrix(const float *a, const float *b, float *c);


### PR DESCRIPTION
`float` can be a typo: `cross3()` doesn't return any value and its
return value is not used when invoked from `eval.c`.