### PR TITLE
[GBM/DRM] Use GBMOpenDisplay to get display while getting extensions

### DIFF
--- a/src/glx/gbm.c
+++ b/src/glx/gbm.c
@@ -212,7 +212,7 @@ static void drm_fb_destroy_callback(struct gbm_bo *bo, void *data)
     struct gbm_device *gbm = gbmdrm_gbm_bo_get_device(bo);
 
     if (fb->fb_id)
-        drmModeRmFB(drm_fd, fb->fb_id);
+        gbmdrm_drmModeRmFB(drm_fd, fb->fb_id);
 
     free(fb);
 }
@@ -260,6 +260,10 @@ static int OpenGBM()
 
 void LoadGBMFunctions()
 {
+    static int hasrun = 0;
+    if(hasrun)
+        return;
+    hasrun = 1;
     if(!gbm || !drm)
         return;
     // load functions

--- a/src/glx/hardext.c
+++ b/src/glx/hardext.c
@@ -154,7 +154,14 @@ void GetHardwareExtensions(int notest)
     int configsFound;
     static EGLConfig pbufConfigs[1];
 
-    eglDisplay = egl_eglGetDisplay(EGL_DEFAULT_DISPLAY);
+#ifndef NO_GBM
+    if (globals4es.usegbm) {
+        GBMLoadFunctions();
+        eglDisplay = GBMOpenDisplay(EGL_DEFAULT_DISPLAY);
+    }
+    else
+#endif
+        eglDisplay = egl_eglGetDisplay(EGL_DEFAULT_DISPLAY);
 
     egl_eglBindAPI(EGL_OPENGL_ES_API);
     if (egl_eglInitialize(eglDisplay, NULL, NULL) != EGL_TRUE) {


### PR DESCRIPTION
This uses `GBMOpenDisplay` to get the display in `getHardwareExtensions`.

It also adds a static variable to check whether LoadGBMFunctions has already run, and adds the `gbmdrm` prefix to `drmMoreRmFB`.

glxgears now runs, with the same performance as my wrapper (and the same problems).