### PR TITLE
Workaround for AmigaOS4

### DIFF
--- a/src/gl/fpe_shader.c
+++ b/src/gl/fpe_shader.c
@@ -22,11 +22,19 @@ static int comments = 1;
 
 #define ShadAppend(S) shad = Append(shad, &shad_cap, S)
 
+#ifdef AMIGA
+//                           2D   Rectangle    3D   CubeMap  Stream
+const char* texvecsize[] = {"vec2", "vec2", "vec2", "vec3", "vec2"};
+const char* texxyzsize[] = {"st", "st",    "st",  "stp",   "st"};
+//                          2D              Rectangle      3D          CubeMap          Stream
+const char* texname[] = {"texture2D", "texture2D", "texture2D", "textureCube", "textureStreamIMG"};    // textureRectange and 3D are emulated with 2D
+#else
 //                           2D   Rectangle    3D   CubeMap  Stream
 const char* texvecsize[] = {"vec4", "vec2", "vec2", "vec3", "vec2"};
 const char* texxyzsize[] = {"stpq", "st",    "st",  "stp",   "st"};
 //                          2D              Rectangle      3D          CubeMap          Stream
 const char* texname[] = {"texture2DProj", "texture2D", "texture2D", "textureCube", "textureStreamIMG"};    // textureRectange and 3D are emulated with 2D
+#endif
 const char* texnoproj[] = {"texture2D", "texture2D", "texture2D", "textureCube", "textureStreamIMG"};    // textureRectange and 3D are emulated with 2D
 const char* texsampler[] = {"sampler2D", "sampler2D", "sampler2D", "samplerCube", "samplerStreamIMG"};
 int texnsize[] = {2, 2, 3, 3, 2};


### PR DESCRIPTION
Workaround: AmigaOS4's W3D Nova doesn't support SPIR-V OpImageSampleProjImplicitLod, therefore OGLES2 cannot handle texture2Dproj here for now.