### PR TITLE
Amiga fix

### DIFF
--- a/src/agl/agl.h
+++ b/src/agl/agl.h
@@ -18,7 +18,7 @@
 #ifndef OGLES2_OGLES2_DEFS_H
 // it would be better to have an include with only the CreateContextTags enum difed, to avoid conflict
 //  of other typedef with full OpenGL header file...
-#include <ogles2/ogles2_defs.h>
+//#include <ogles2/ogles2_defs.h>
 #endif
 
 void* aglCreateContext(ULONG * errcode, struct TagItem * tags);

--- a/src/glx/lookup.c
+++ b/src/glx/lookup.c
@@ -73,7 +73,7 @@ void *gl4es_glXGetProcAddress(const char *name) {
     return gl4es_GetProcAddress(name);
 }
 #ifdef AMIGAOS4
-void* aglGetProcAddress(const char* name) AliasExport("gl4es_glXGetProcAddress");
+//void* aglGetProcAddress(const char* name) AliasExport("gl4es_glXGetProcAddress");
 #else
 void* glXGetProcAddress(const char* name) AliasExport("gl4es_glXGetProcAddress");
 void* glXGetProcAddressARB(const char* name) AliasExport("gl4es_glXGetProcAddress");


### PR DESCRIPTION
Got rid of the "illegal" ogles2_defs.h include in agl.h which caused typedef conflicts elsewhere.
And in glx/lookup.c there was a redefined aglGetProcAddress (already implemented in agl/lookup.c).