### PR TITLE
Export API to set external GetProcAddress, getMainFBSize, allow disable library loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ option(STATICLIB "Set to ON to build a static version of gl4es" ${STATICLIB})
 option(GBM "Set to ON to not build GBM interface" ${GBM})
 option(USE_CCACHE "Set to ON to use ccache if present in the system" ${USE_CCACHE})
 option(USE_CLOCK "Set to ON to use clock_gettime instead of gttimeofday for LIBGL_FPS" ${USE_CLOCK})
+option(NO_LOADER "disable library loader (useful for static library with NOEGL, NOX11, use include/gl4esinit.h)" ${NO_LOADER})
+option(NO_INIT_CONSTRUCTOR "disable automatic initialization (useful for static library, use include/gl4esinit.h)" ${NO_INIT_CONSTRUCTOR})
 
 # Pandora
 if(PANDORA)
@@ -105,6 +107,14 @@ endif()
 #NOX11
 if(USE_CLOCK)
     add_definitions(-DUSE_CLOCK)
+endif()
+
+if(NO_LOADER)
+    add_definitions(-DNO_LOADER)
+endif()
+
+if(NO_INIT_CONSTRUCTOR)
+    add_definitions(-DNO_INIT_CONSTRUCTOR)
 endif()
 
 #DEFAULT_ES=2

--- a/include/gl4esinit.h
+++ b/include/gl4esinit.h
@@ -1,0 +1,13 @@
+
+#ifndef _GL4ESINCLUDE_INIT_H_
+#define _GL4ESINCLUDE_INIT_H_
+
+// set driver GetProcAddress implementation. required for hardext detection with NOEGL or when loader is disabled
+void set_getprocaddress(void *(*new_proc_address)(const char *));
+// reguired with NOEGL
+void set_getmainfbsize(void (*new_getMainFBSize)(int* width, int* height));
+// do this before any GL calls if init constructors disabled
+void initialize_gl4es(void);
+// wrapped GetProcAddress
+void *gl4es_GetProcAddress(const char *name);
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,7 +126,7 @@ SET(GL_H
 
 set_source_files_properties(gl/build_info.c PROPERTIES OBJECT_OUTPUTS "dummy.c")
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND NOT NO_LOADER)
     include_directories(glx)
 #    aux_source_directory(glx GLX_SOURCES)
 #    list(APPEND GL_SOURCES ${GLX_SOURCES})
@@ -150,27 +150,16 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         glx/utils.h
     )
 else()
+    include_directories(glx)
+    list(APPEND GL_SRC
+        glx/hardext.c
+    )
     message(STATUS "Not on Linux: building without GLX support.")
-endif()
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
-    include_directories(glx)
-    list(APPEND GL_SRC
-        glx/hardext.c
-    )
-endif()
-
-if(APPLE)
-    include_directories(glx)
-    list(APPEND GL_SRC
-        glx/hardext.c
-    )
 endif()
 
 if(AMIGAOS4)
     include_directories(agl)
     list(APPEND GL_SRC
-        glx/hardext.c
         glx/gbm.c
         glx/glx.c
         agl/lookup.c

--- a/src/gl/framebuffers.c
+++ b/src/gl/framebuffers.c
@@ -1376,7 +1376,7 @@ void gl4es_glFramebufferTextureLayer(	GLenum target, GLenum attachment, GLuint t
     gl4es_glFramebufferTexture2D(target, attachment, GL_TEXTURE_2D, texture,	level); // Force Texture2D, ignore layer (should track?)...
 }
 
-void gl4es_getMainFBSize(GLint* width, GLint* height);
+void (*gl4es_getMainFBSize)(GLint* width, GLint* height);
 
 void gl4es_glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter) {
     // mask will be ignored
@@ -1439,7 +1439,8 @@ void gl4es_glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1,
         fbowidth = glstate->fbo.mainfbo_width;
         fboheight = glstate->fbo.mainfbo_height;
         if(glstate->fbo.mainfbo_width!=dstX1 || glstate->fbo.mainfbo_height!=dstY1) {
-            gl4es_getMainFBSize(&glstate->fbo.mainfbo_width, &glstate->fbo.mainfbo_height);
+            if (gl4es_getMainFBSize)
+                gl4es_getMainFBSize(&glstate->fbo.mainfbo_width, &glstate->fbo.mainfbo_height);
         }
     } else {
         fbowidth  = glstate->fbo.fbo_draw->width;

--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -53,6 +53,14 @@ void glx_init();
 
 static int inited = 0;
 
+void set_getmainfbsize(void (*new_getMainFBSize)(int* w, int* h)) {
+    gl4es_getMainFBSize = (void*)new_getMainFBSize;
+}
+
+void set_getprocaddress(void *(*new_proc_address)(const char *)) {
+    gles_getProcAddress = new_proc_address;
+}
+
 #ifdef NO_INIT_CONSTRUCTOR
 __attribute__((visibility("default")))
 #else
@@ -187,7 +195,7 @@ void initialize_gl4es() {
 #endif
 
 #if (defined(NOEGL) && !defined(ANDROID) && !defined(__APPLE__)) || defined(__EMSCRIPTEN__)
-    int gl4es_notest = 1;
+    int gl4es_notest = !gles_getProcAddress;
 #else
     int gl4es_notest = IsEnvVarTrue("LIBGL_NOTEST");
 #endif
@@ -208,7 +216,7 @@ void initialize_gl4es() {
 
     GetHardwareExtensions(gl4es_notest);
 
-#if !defined(__EMSCRIPTEN__) && !defined(__APPLE__)
+#if !defined(NO_LOADER)
     if(globals4es.usegbm)
         LoadGBMFunctions();
     if(globals4es.usegbm && !(gbm && drm)) {

--- a/src/gl/loader.h
+++ b/src/gl/loader.h
@@ -83,18 +83,14 @@ typedef EGLSurface (*eglCreateStreamProducerSurfaceKHR_PTR)(EGLDisplay dpy, EGLC
 #include <string.h>
 
 #include "../glx/hardext.h"
-
+extern void *(*gles_getProcAddress)(const char *name);
+void (*gl4es_getMainFBSize)(GLint* width, GLint* height);
+void *proc_address(void *lib, const char *name);
 // will become references to dlopen'd gles and egl
 extern void *gles, *egl, *bcm_host, *vcos, *gbm, *drm;
-#ifdef AMIGAOS4
-#define proc_address(lib, name) os4GetProcAddress(name)
-#elif defined(__EMSCRIPTEN__)
-void *emscripten_GetProcAddress(const char *name);
-#define proc_address(lib, name) emscripten_GetProcAddress(name)
-#else // AMIGAOS4
-#define proc_address(lib, name) dlsym(lib, name)
-void *open_lib(const char **names, const char *override);
-#endif // AMIGAOS4
+#if defined __APPLE__ || defined __EMSCRIPTEN__
+#define NO_LOADER
+#endif
 
 #define WARN_NULL(name) if (name == NULL) LOGD("warning, " #name " is NULL\n");
 

--- a/src/glx/glx.c
+++ b/src/glx/glx.c
@@ -123,7 +123,7 @@ static GLXContext fbContext = NULL;
 static GLuint current_fb = 0;
 
 #endif //NOX11
-void gl4es_getMainFBSize(GLint* width, GLint* height) {
+void glx_getMainFBSize(GLint* width, GLint* height) {
 #if !defined(NOX11) && !defined(NOEGL) && !defined(ANDROID)
     // noegl, no updating of framebuffer size
     DBG(printf("gl4es_getMainFBSize() %dx%d -> ", *width, *height);)
@@ -493,6 +493,8 @@ static void init_liveinfo() {
 void glx_init() {
     // init map_drawable
     int ret;
+    if( !gl4es_getMainFBSize )
+        gl4es_getMainFBSize = glx_getMainFBSize;
     MapDrawable = kh_init(mapdrawable);
     kh_put(mapdrawable, MapDrawable, 1, &ret);
     kh_del(mapdrawable, MapDrawable, 1);


### PR DESCRIPTION
This allows to disable library loading and set GetProcAddress implementation from application when it already created GLES context/surface and do not need any context management/loading from gl4es. This removes glx/* dependencies except hardext.c with NOEGL and NOX11 enabled