### PR TITLE
(Amiga) Fixes

### DIFF
--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -216,7 +216,7 @@ void initialize_gl4es() {
 
     GetHardwareExtensions(gl4es_notest);
 
-#if !defined(NO_LOADER)
+#if !defined(NO_LOADER) && !defined(NO_GBM)
     if(globals4es.usegbm)
         LoadGBMFunctions();
     if(globals4es.usegbm && !(gbm && drm)) {

--- a/src/gl/loader.c
+++ b/src/gl/loader.c
@@ -165,7 +165,7 @@ void *(*gles_getProcAddress)(const char *name);
 void *proc_address(void *lib, const char *name) {
     if (gles_getProcAddress)
         return gles_getProcAddress(name);
-#ifdef AMIGAOS64
+#ifdef AMIGAOS4
     return os4GetProcAddress(name);
 #elif defined __EMSCRIPTEN__
     void *emscripten_GetProcAddress(const char *name);


### PR DESCRIPTION
ifdef-typo in gl/loader.c (AMIGAOS64 instead of AMIGAOS4) and missing NO_GBM check in gl/init.c