### PR TITLE
Use of auto-declared `gl_Sampler`* in ARB shaders

### DIFF
--- a/src/gl/arbconverter.c
+++ b/src/gl/arbconverter.c
@@ -171,22 +171,7 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 		glsl->error_msg = strdup(str); continue
 #define curStatusPtr &curStatus
 	do {
-		APPEND_OUTPUT("#version 120\n", 13)
-		
-		if (!vertex) {
-			// sampler2DRect is not in the GLSL 1.20 specification and is a reserved keyword...
-			APPEND_OUTPUT(
-				"uniform sampler1D samplers1D[" MAX_TEX_STR "];\n"
-				"uniform sampler2D samplers2D[" MAX_TEX_STR "];\n"
-				"uniform sampler3D samplers3D[" MAX_TEX_STR "];\n"
-				"uniform samplerCube samplersCube[" MAX_TEX_STR "];\n"
-				/* "uniform sampler2DRect samplersRect[" MAX_TEX_STR "];\n" */,
-				/* 170 + 5 * MAX_TEX_STRLEN */
-				132 + 4 * MAX_TEX_STRLEN
-			)
-		}
-		
-		APPEND_OUTPUT("\nvoid main() {\n", 15)
+		APPEND_OUTPUT("#version 120\n\nvoid main() {\n", 28)
 		
 		for (; (varIdx < curStatus.variables.size) && (curStatus.status != ST_ERROR); ++varIdx) {
 			varPtr = curStatus.variables.vars[varIdx];

--- a/src/gl/arbconverter.c
+++ b/src/gl/arbconverter.c
@@ -1,7 +1,6 @@
 #include "arbconverter.h"
 
 #include <stddef.h>
-#include <stdio.h>
 
 // MAX_TEX
 #include "state.h"
@@ -52,6 +51,8 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 	}
 	
 	codeStart += 10;
+	
+	ARBCONV_DBG_HEAVY(printf("Generating code for:\n%s\n", codeStart);)
 	
 	sCurStatus curStatus;
 	initStatus(&curStatus, codeStart);

--- a/src/gl/arbhelper.c
+++ b/src/gl/arbhelper.c
@@ -339,13 +339,15 @@ int appendString(sCurStatus *curStatusPtr, const char *str, size_t strLen) {
 		curStatusPtr->outputEnd += curStatusPtr->outputString - oldOut;
 	}
 	
-	ARBCONV_DBG_HEAVY(ARBCONV_DBG(printf(
-		"Appending to %p (%p + %ld = %p)\n",
+	ARBCONV_DBG_HEAVY(ARBCONV_DBG(
+	char *dup = malloc((strLen + 1) * sizeof(char)); memcpy(dup, str, strLen); dup[strLen] = '\0'; printf(
+		"Appending '%s' to %p (%p + %ld = %p)\n",
+		dup,
 		curStatusPtr->outputEnd,
 		curStatusPtr->outputString,
 		curStatusPtr->outLen,
 		curStatusPtr->outputString + curStatusPtr->outLen
-	);)
+	); free(dup);)
 	if (curStatusPtr->outputEnd != curStatusPtr->outputString + curStatusPtr->outLen) {
 		printf("\033[01;31mERROR!!!\033[m\n%s\n", str);
 		curStatusPtr->status = ST_ERROR;

--- a/src/gl/arbhelper.h
+++ b/src/gl/arbhelper.h
@@ -7,6 +7,8 @@
 
 //#define DEBUG
 #ifdef DEBUG
+#include <stdio.h>
+
 // ARBCONV_DBG - general ArbConverter debug logs
 #define ARBCONV_DBG(a) a
 // ARBCONV_DBG_LP - code loop ArbConverter debug logs

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -518,12 +518,12 @@ int resolveOutput(sCurStatus_NewVar *newVar, int vertex) {
 				// result.color.primary => gl_FrontColor
 				free(tok);
 				pushArray((sArray*)&newVar->var->init, strdup("gl_FrontColor"));
-				newVar->var->init.strings_total_len = 8;
+				newVar->var->init.strings_total_len = 13;
 			} else if (!strcmp(tok, "secondary")) {
-				// result.color.secondary => gl_SecondaryColor
+				// result.color.secondary => gl_FrontSecondaryColor
 				free(tok);
-				pushArray((sArray*)&newVar->var->init, strdup("gl_SecondaryColor"));
-				newVar->var->init.strings_total_len = 17;
+				pushArray((sArray*)&newVar->var->init, strdup("gl_FrontSecondaryColor"));
+				newVar->var->init.strings_total_len = 22;
 			} else {
 				ARBCONV_DBG_RE(printf("Failed to get output: result.color.%s\n", tok);)
 				free(tok);


### PR DESCRIPTION
This PR changes various things in the ARB shader generator:
- The samplers are now left to be declared by shaderconv ([TODO])
- The arrays are now initialized by iterating over the indexes instead of using an array constructor
- If the length of an array is not defined, automatically declare it
- Bug fixes in the `resolveOutput` function in vertex shaders