### PR TITLE
Removed almost all dependancies to state.h in ARB converter

### DIFF
--- a/src/gl/arbconverter.c
+++ b/src/gl/arbconverter.c
@@ -229,7 +229,7 @@ char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int
 				fflush(stdout);
 			)
 			
-			generateVariablePst(&curStatus, vertex, &*error_msg, varPtr);
+			generateVariablePst(&curStatus, vertex, error_msg, varPtr);
 		}
 		if (curStatus.status == ST_ERROR) {
 			--varIdx;

--- a/src/gl/arbconverter.c
+++ b/src/gl/arbconverter.c
@@ -2,17 +2,19 @@
 
 #include <stddef.h>
 
-// MAX_TEX
-#include "state.h"
 #include "arbgenerator.h"
 #include "arbhelper.h"
 #include "arbparser.h"
 #include "khash.h"
 
-char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
-	glsl->error_ptr = -1; // Reinit error pointer
+#define FAIL(str) curStatus.status = ST_ERROR; if (*error_msg) free(*error_msg); \
+		*error_msg = strdup(str); continue
+#define curStatusPtr &curStatus
+char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int *error_ptr) {
+	*error_ptr = -1; // Reinit error pointer
 	
 	const char *codeStart = code;
+	// Not sure this is really OK...
 	if ((codeStart[0] != '!') || (codeStart[1] != '!')) {
 		while (1) {
 			while ((*codeStart != '!') && (*codeStart != '\0')) {
@@ -20,10 +22,10 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 			}
 			if (*codeStart == '\0') {
 				// Invalid start
-				if (glsl->error_msg)
-					free(glsl->error_msg);
-				glsl->error_msg = strdup("Invalid program start");
-				glsl->error_ptr = 0;
+				if (*error_msg)
+					free(*error_msg);
+				*error_msg = strdup("Invalid program start");
+				*error_ptr = 0;
 				return NULL;
 			}
 			if ((codeStart[0] == '!') && (codeStart[1] == '!')) {
@@ -34,18 +36,18 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 	}
 	if (vertex) {
 		if (strncmp(codeStart, "!!ARBvp1.0", 10)) {
-			if (glsl->error_msg)
-				free(glsl->error_msg);
-			glsl->error_msg = strdup("Invalid program start");
-			glsl->error_ptr = codeStart - code;
+			if (*error_msg)
+				free(*error_msg);
+			*error_msg = strdup("Invalid program start");
+			*error_ptr = codeStart - code;
 			return NULL;
 		}
 	} else {
 		if (strncmp(codeStart, "!!ARBfp1.0", 10)) {
-			if (glsl->error_msg)
-				free(glsl->error_msg);
-			glsl->error_msg = strdup("Invalid program start");
-			glsl->error_ptr = codeStart - code;
+			if (*error_msg)
+				free(*error_msg);
+			*error_msg = strdup("Invalid program start");
+			*error_ptr = codeStart - code;
 			return NULL;
 		}
 	}
@@ -98,7 +100,7 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 			fflush(stdout);
 		)
 		
-		parseToken(&curStatus, vertex, glsl);
+		parseToken(&curStatus, vertex, error_msg);
 		
 		readNextToken(&curStatus);
 	}
@@ -152,7 +154,7 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 		}
 		printf("\n");)
 		
-		glsl->error_ptr = curStatus.codePtr - code;
+		*error_ptr = curStatus.codePtr - code;
 		
 		// We have errored, output NULL
 		freeStatus(&curStatus);
@@ -168,9 +170,6 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 	size_t instIdx = (size_t)0;
 	sInstruction *instPtr;
 	
-#define FAIL(str) curStatus.status = ST_ERROR; if (glsl->error_msg) free(glsl->error_msg); \
-		glsl->error_msg = strdup(str); continue
-#define curStatusPtr &curStatus
 	do {
 		APPEND_OUTPUT("#version 120\n\nvoid main() {\n", 28)
 		
@@ -182,11 +181,11 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 				fflush(stdout);
 			)
 			
-			generateVariablePre(&curStatus, vertex, glsl, varPtr);
+			generateVariablePre(&curStatus, vertex, error_msg, varPtr);
 		}
 		if (curStatus.status == ST_ERROR) {
 			--varIdx;
-			glsl->error_ptr = 1;
+			*error_ptr = 1;
 			break;
 		}
 		
@@ -213,11 +212,11 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 				fflush(stdout);
 			)
 			
-			generateInstruction(&curStatus, vertex, glsl, instPtr);
+			generateInstruction(&curStatus, vertex, error_msg, instPtr);
 		}
 		if (curStatus.status == ST_ERROR) {
 			--instIdx;
-			glsl->error_ptr = curStatus.instructions.insts[instIdx]->codeLocation - code;
+			*error_ptr = curStatus.instructions.insts[instIdx]->codeLocation - code;
 			break;
 		}
 		
@@ -230,11 +229,11 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 				fflush(stdout);
 			)
 			
-			generateVariablePst(&curStatus, vertex, glsl, varPtr);
+			generateVariablePst(&curStatus, vertex, &*error_msg, varPtr);
 		}
 		if (curStatus.status == ST_ERROR) {
 			--varIdx;
-			glsl->error_ptr = 2;
+			*error_ptr = 2;
 			break;
 		}
 		
@@ -286,11 +285,11 @@ char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl) {
 		
 		printf("\nBuffered output:\n%s\n", curStatus.outputString);)
 		
-		if (glsl->error_ptr != -1) {
-			if (glsl->error_msg)
-				free(glsl->error_msg);
-			glsl->error_msg = strdup("Not enough memory(?)");
-			glsl->error_ptr = 0;
+		if (*error_ptr == -1) {
+			if (*error_msg)
+				free(*error_msg);
+			*error_msg = strdup("Not enough memory(?)");
+			*error_ptr = 0;
 		}
 		
 		// We have errored, output NULL

--- a/src/gl/arbconverter.h
+++ b/src/gl/arbconverter.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 
-typedef struct glsl_s glsl_t;
-char* gl4es_convertARB(const char* const code, int vertex, glsl_t *glsl);
+char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int *error_ptr);
 
 #endif // _GL4ES_ARBCONVERTER_H_

--- a/src/gl/arbgenerator.c
+++ b/src/gl/arbgenerator.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 
 #include "arbhelper.h"
-#include "state.h"
 
 #define FAIL(str) curStatusPtr->status = ST_ERROR; if (*error_msg) free(*error_msg); \
 		*error_msg = strdup(str); return

--- a/src/gl/arbgenerator.c
+++ b/src/gl/arbgenerator.c
@@ -7,9 +7,9 @@
 #include "arbhelper.h"
 #include "state.h"
 
-#define FAIL(str) curStatusPtr->status = ST_ERROR; if (glsl->error_msg) free(glsl->error_msg); \
-		glsl->error_msg = strdup(str); return
-void generateVariablePre(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sVariable *varPtr) {
+#define FAIL(str) curStatusPtr->status = ST_ERROR; if (*error_msg) free(*error_msg); \
+		*error_msg = strdup(str); return
+void generateVariablePre(sCurStatus *curStatusPtr, int vertex, char **error_msg, sVariable *varPtr) {
 	if (varPtr->type == VARTYPE_CONST) {
 		return;
 	}
@@ -74,7 +74,7 @@ void generateVariablePre(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sVa
 	
 	APPEND_OUTPUT(";\n", 2)
 }
-void generateInstruction(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sInstruction *instPtr) {
+void generateInstruction(sCurStatus *curStatusPtr, int vertex, char **error_msg, sInstruction *instPtr) {
 	// Data access and output
 #define SWIZ(i, s) instPtr->vars[i].swizzle[s]
 #define SWIZORX(i, s) SWIZ(i, s) ? SWIZ(i, s) : (s + 1)
@@ -1026,7 +1026,7 @@ void generateInstruction(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sIn
 #undef PUSH_SWIZZLE
 #undef SWIZ
 }
-void generateVariablePst(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sVariable *varPtr) {
+void generateVariablePst(sCurStatus *curStatusPtr, int vertex, char **error_msg, sVariable *varPtr) {
 	if (varPtr->type != VARTYPE_OUTPUT) {
 		return;
 	}

--- a/src/gl/arbgenerator.h
+++ b/src/gl/arbgenerator.h
@@ -11,8 +11,8 @@
 		}
 #define APPEND_OUTPUT2(str) APPEND_OUTPUT(str, (size_t)-1)
 
-void generateVariablePre(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sVariable *varPtr);
-void generateInstruction(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sInstruction *instPtr);
-void generateVariablePst(sCurStatus *curStatusPtr, int vertex, glsl_t *glsl, sVariable *varPtr);
+void generateVariablePre(sCurStatus *curStatusPtr, int vertex, char **error_msg, sVariable *varPtr);
+void generateInstruction(sCurStatus *curStatusPtr, int vertex, char **error_msg, sInstruction *instPtr);
+void generateVariablePst(sCurStatus *curStatusPtr, int vertex, char **error_msg, sVariable *varPtr);
 
 #endif // _GL4ES_ARBGENERATOR_H_

--- a/src/gl/arbhelper.c
+++ b/src/gl/arbhelper.c
@@ -1,6 +1,6 @@
 #include "arbhelper.h"
 
-#include "state.h"
+#include "../config.h"
 
 #define SIZE_THRESHOLD 0x80
 void *resize(void** obj, size_t* cap, size_t esize) {

--- a/src/gl/arbhelper.h
+++ b/src/gl/arbhelper.h
@@ -311,6 +311,5 @@ void freeStatus(sCurStatus* curStatus);
 
 int appendString(sCurStatus *curStatusPtr, const char *str, size_t strLen);
 
-typedef struct glsl_s glsl_t;
 
 #endif // _GL4ES_ARBHELPER_H_

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -4,7 +4,7 @@
 
 #include "arbhelper.h"
 // MAX_TEX
-#include "state.h"
+#include "../config.h"
 
 // ARBCONV_DBG_RE - resolve* error ArbConverter debug logs
 #define ARBCONV_DBG_RE(...) printf(__VA_ARGS__);

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 #include "arbhelper.h"
+// MAX_TEX
 #include "state.h"
 
 // ARBCONV_DBG_RE - resolve* error ArbConverter debug logs
@@ -2166,9 +2167,9 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 	return (char**)0xFFFFFFFFU; // Unreachable
 }
 
-#define FAIL(str) curStatusPtr->status = ST_ERROR; if (glsl->error_msg) free(glsl->error_msg); \
-		glsl->error_msg = strdup(str); return
-void parseToken(sCurStatus* curStatusPtr, int vertex, glsl_t *glsl) {
+#define FAIL(str) curStatusPtr->status = ST_ERROR; if (*error_msg) free(*error_msg); \
+		*error_msg = strdup(str); return
+void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg) {
 	if (((curStatusPtr->curToken == TOK_UNKNOWN) && (curStatusPtr->status != ST_LINE_COMMENT))
 		|| (curStatusPtr->curToken == TOK_NULL)) {
 		FAIL("Unknown token");

--- a/src/gl/arbparser.h
+++ b/src/gl/arbparser.h
@@ -6,6 +6,6 @@
 #include "arbhelper.h"
 
 eToken readNextToken(sCurStatus* curStatus);
-void parseToken(sCurStatus *curStatus, int vertex, glsl_t *glsl);
+void parseToken(sCurStatus *curStatus, int vertex, char **error_msg);
 
 #endif // _GL4ES_ARBPARSER_H_

--- a/src/gl/oldprogram.c
+++ b/src/gl/oldprogram.c
@@ -140,7 +140,7 @@ void gl4es_glProgramStringARB(GLenum target, GLenum format, GLsizei len, const G
     old->string = calloc(1, len + 1);
     memcpy(old->string, string, len);
     // Convert to GLSL
-    old->shader->source = gl4es_convertARB(old->string, vertex, glstate->glsl);
+    old->shader->source = gl4es_convertARB(old->string, vertex, &glstate->glsl->error_msg, &glstate->glsl->error_ptr);
     if (!old->shader->source) {
         errorShim(GL_INVALID_OPERATION);
         return;


### PR DESCRIPTION
This PR removes dependencies to `state.h` from the files `arbconverter.c`, `arbgenerator.c`, `arbhelper.c` and `arbparser.c` (and sometimes include `config.h` to have `MAX_TEX`).