### PR TITLE
Changed the way gl_fogFragCoord is handled

### DIFF
--- a/src/gl/arbconverter.c
+++ b/src/gl/arbconverter.c
@@ -13,6 +13,7 @@
 char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int *error_ptr) {
 	*error_ptr = -1; // Reinit error pointer
 	
+	int hasFogFragCoord = 0;
 	const char *codeStart = code;
 	// Not sure this is really OK...
 	if ((codeStart[0] != '!') || (codeStart[1] != '!')) {
@@ -100,7 +101,7 @@ char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int
 			fflush(stdout);
 		)
 		
-		parseToken(&curStatus, vertex, error_msg);
+		parseToken(&curStatus, vertex, error_msg, &hasFogFragCoord);
 		
 		readNextToken(&curStatus);
 	}
@@ -174,6 +175,9 @@ char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int
 		if (vertex) {
 			// Add a structure (for addresses) with only an 'x' component
 			APPEND_OUTPUT("#version 120\n\nstruct _structOnlyX { int x; };\n\nvoid main() {\n", 61)
+			if (hasFogFragCoord) {
+				APPEND_OUTPUT("\tvec4 gl_fogFragCoordTemp = vec4(gl_fogFragCoord);\n", 51)
+			}
 		} else {
 			// No address
 			APPEND_OUTPUT("#version 120\n\nvoid main() {\n", 28)
@@ -243,6 +247,9 @@ char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int
 			break;
 		}
 		
+		if (hasFogFragCoord) {
+			APPEND_OUTPUT("\tgl_fogFragCoord = gl_fogFragCoordTemp.x;\n", 42)
+		}
 		APPEND_OUTPUT("}\n", 2)
 	} while (0);
 	

--- a/src/gl/arbgenerator.c
+++ b/src/gl/arbgenerator.c
@@ -9,6 +9,8 @@
 #define FAIL(str) curStatusPtr->status = ST_ERROR; if (*error_msg) free(*error_msg); \
 		*error_msg = strdup(str); return
 void generateVariablePre(sCurStatus *curStatusPtr, int vertex, char **error_msg, sVariable *varPtr) {
+	(void)vertex;
+	
 	if (varPtr->type == VARTYPE_CONST) {
 		return;
 	} else if (varPtr->type == VARTYPE_ADDRESS) {
@@ -1025,6 +1027,8 @@ void generateInstruction(sCurStatus *curStatusPtr, int vertex, char **error_msg,
 #undef SWIZ
 }
 void generateVariablePst(sCurStatus *curStatusPtr, int vertex, char **error_msg, sVariable *varPtr) {
+	(void)vertex;
+	
 	if (varPtr->type != VARTYPE_OUTPUT) {
 		return;
 	}

--- a/src/gl/arbgenerator.c
+++ b/src/gl/arbgenerator.c
@@ -24,17 +24,8 @@ void generateVariablePre(sCurStatus *curStatusPtr, int vertex, char **error_msg,
 	
 	int skipNL = 0;
 	switch (varPtr->type) {
-	case VARTYPE_OUTPUT:
-		if (!vertex && !strcmp(varPtr->init.strings[0], "gl_FogFragCoord")) {
-			// If we are setting from gl_FogFragCoord, then extend to vec4
-			APPEND_OUTPUT(" = vec4(", 8)
-			APPEND_OUTPUT(varPtr->init.strings[0], varPtr->init.strings_total_len)
-			APPEND_OUTPUT(")", 1)
-			break;
-		}
-		
-		/* FALLTHROUGH */
 	case VARTYPE_ATTRIB:
+	case VARTYPE_OUTPUT:
 	case VARTYPE_PARAM:
 		APPEND_OUTPUT(" = ", 3)
 		APPEND_OUTPUT(varPtr->init.strings[0], varPtr->init.strings_total_len)
@@ -274,14 +265,8 @@ void generateInstruction(sCurStatus *curStatusPtr, int vertex, char **error_msg,
 	
 	// Instruction variable pushing
 #define PUSH_MASKDST(i) \
-		PUSH_VARNAME(i)                                                         \
-		if (vertex || (instPtr->vars[0].var->type != VARTYPE_CONST)             \
-		 || strcmp(instPtr->vars[0].var->init.strings[0], "gl_FogFragCoord")) { \
-			/* If we are setting gl_FogFragCoord, do not put the '.x' */        \
-			PUSH_DSTMASK(i, i)                                                  \
-		} else {                                                                \
-			SWIZ(i, 0) = SWIZ_X;                                                \
-		}
+		PUSH_VARNAME(i)    \
+		PUSH_DSTMASK(i, i)
 #define PUSH_VECTSRC(i) \
 		PUSH_VARNAME(i)                    \
 		if (SWIZ(i, 0) != SWIZ_NONE) {     \
@@ -1048,9 +1033,5 @@ void generateVariablePst(sCurStatus *curStatusPtr, int vertex, char **error_msg,
 	APPEND_OUTPUT(varPtr->init.strings[0], varPtr->init.strings_total_len)
 	APPEND_OUTPUT(" = ", 3)
 	APPEND_OUTPUT2(varPtr->names[0])
-	if (!vertex && !strcmp(varPtr->init.strings[0], "gl_FogFragCoord")) {
-		// If we are setting gl_FogFragCoord, then only take the x component
-		APPEND_OUTPUT(".x", 2)
-	}
 	APPEND_OUTPUT(";\n", 2)
 }

--- a/src/gl/arbparser.h
+++ b/src/gl/arbparser.h
@@ -6,6 +6,6 @@
 #include "arbhelper.h"
 
 eToken readNextToken(sCurStatus* curStatus);
-void parseToken(sCurStatus *curStatus, int vertex, char **error_msg);
+void parseToken(sCurStatus *curStatus, int vertex, char **error_msg, int *hasFogFragCoord);
 
 #endif // _GL4ES_ARBPARSER_H_


### PR DESCRIPTION
This PR tries to have a correct handling of `result.fogcoord` in ARB shaders.