### PR TITLE
Supported ARB options extension

### DIFF
--- a/src/gl/arbconverter.c
+++ b/src/gl/arbconverter.c
@@ -250,6 +250,31 @@ char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int
 		if (hasFogFragCoord) {
 			APPEND_OUTPUT("\tgl_FogFragCoord = gl4es_FogFragCoordTemp.x;\n", 45)
 		}
+		switch (curStatus.fogType) {
+		case FOG_NONE:
+			break;
+		case FOG_EXP:
+			APPEND_OUTPUT(
+				"\tgl_FragColor.rgb = mix(gl_Fog.color.rgb, gl_Color.rgb, "
+				"clamp(exp(-gl_Fog.density * gl_FogFragCoord), 0., 1.)",
+				109
+			)
+			break;
+		case FOG_EXP2:
+			APPEND_OUTPUT(
+				"\tgl_FragColor.rgb = mix(gl_Fog.color.rgb, gl_Color.rgb, "
+				"clamp(exp(-(gl_Fog.density * gl_FogFragCoord)*(gl_Fog.density * gl_FogFragCoord)), 0., 1.)",
+				136
+			)
+			break;
+		case FOG_LINEAR:
+			APPEND_OUTPUT(
+				"\tgl_FragColor.rgb = mix(gl_Fog.color.rgb, gl_Color.rgb, "
+				"clamp((gl_Fog.end - gl_FogFragCoord) * gl_Fog.scale, 0., 1.)",
+				116
+			)
+			break;
+		}
 		APPEND_OUTPUT("}\n", 2)
 	} while (0);
 	

--- a/src/gl/arbconverter.c
+++ b/src/gl/arbconverter.c
@@ -264,7 +264,7 @@ char* gl4es_convertARB(const char* const code, int vertex, char **error_msg, int
 			APPEND_OUTPUT(
 				"\tgl_FragColor.rgb = mix(gl_Fog.color.rgb, gl_Color.rgb, "
 				"clamp(exp(-(gl_Fog.density * gl_FogFragCoord)*(gl_Fog.density * gl_FogFragCoord)), 0., 1.)",
-				136
+				146
 			)
 			break;
 		case FOG_LINEAR:

--- a/src/gl/arbhelper.c
+++ b/src/gl/arbhelper.c
@@ -275,6 +275,7 @@ void initStatus(sCurStatus* curStatus, const char* code) {
 	curStatus->varsMap = kh_init(variables);
 	initArray((sArray*)&curStatus->variables);
 	initArray((sArray*)&curStatus->instructions);
+	curStatus->fogType = FOG_NONE;
 	
 	initArray((sArray*)&curStatus->_fixedNewVar);
 	curStatus->_fixedNewVar.var = NULL;

--- a/src/gl/arbhelper.h
+++ b/src/gl/arbhelper.h
@@ -301,9 +301,10 @@ typedef struct _sCurStatus {
 	sVariable    *texCUBE;
 	sVariable    *texRECT;
 	
-	khash_t(variables)    *varsMap;
-	sVariables            variables;
-	sInstructions         instructions;
+	khash_t(variables) *varsMap;
+	sVariables         variables;
+	sInstructions      instructions;
+	enum { FOG_NONE, FOG_EXP, FOG_EXP2, FOG_LINEAR } fogType;
 } sCurStatus;
 
 void initStatus(sCurStatus* curStatus, const char* code);

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -3589,6 +3589,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, int *has
 		case TOK_END_OF_INST:
 			if (!strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_precision_hint_fastest")) {
 				// Nothing to do
+			} else if (!strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_precision_hint_nicest")) {
+				// Nothing to do
 			} else if (!vertex && !strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_exp")) {
 				if (curStatusPtr->fogType != FOG_NONE) {
 					FAIL("Only one of ARB_fog_exp, ARB_fog_exp2 or ARB_fog_linear must be enabled in an ARB shader");

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -3589,8 +3589,21 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, int *has
 		case TOK_END_OF_INST:
 			if (!strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_precision_hint_fastest")) {
 				// Nothing to do
-			} else if (!strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_linear")) {
-				// To do?
+			} else if (!vertex && !strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_exp")) {
+				if (curStatusPtr->fogType != FOG_NONE) {
+					FAIL("Only one of ARB_fog_exp, ARB_fog_exp2 or ARB_fog_linear must be enabled in an ARB shader");
+				}
+				curStatusPtr->fogType = FOG_EXP;
+			} else if (!vertex && !strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_exp2")) {
+				if (curStatusPtr->fogType != FOG_NONE) {
+					FAIL("Only one of ARB_fog_exp, ARB_fog_exp2 or ARB_fog_linear must be enabled in an ARB shader");
+				}
+				curStatusPtr->fogType = FOG_EXP2;
+			} else if (!vertex && !strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_linear")) {
+				if (curStatusPtr->fogType != FOG_NONE) {
+					FAIL("Only one of ARB_fog_exp, ARB_fog_exp2 or ARB_fog_linear must be enabled in an ARB shader");
+				}
+				curStatusPtr->fogType = FOG_LINEAR;
 			} else {
 				FAIL("Unknown option");
 			}

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -3592,19 +3592,10 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, int *has
 			} else if (!strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_precision_hint_nicest")) {
 				// Nothing to do
 			} else if (!vertex && !strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_exp")) {
-				if (curStatusPtr->fogType != FOG_NONE) {
-					FAIL("Only one of ARB_fog_exp, ARB_fog_exp2 or ARB_fog_linear must be enabled in an ARB shader");
-				}
 				curStatusPtr->fogType = FOG_EXP;
 			} else if (!vertex && !strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_exp2")) {
-				if (curStatusPtr->fogType != FOG_NONE) {
-					FAIL("Only one of ARB_fog_exp, ARB_fog_exp2 or ARB_fog_linear must be enabled in an ARB shader");
-				}
 				curStatusPtr->fogType = FOG_EXP2;
 			} else if (!vertex && !strcmp(curStatusPtr->curValue.newOpt.optName, "ARB_fog_linear")) {
-				if (curStatusPtr->fogType != FOG_NONE) {
-					FAIL("Only one of ARB_fog_exp, ARB_fog_exp2 or ARB_fog_linear must be enabled in an ARB shader");
-				}
 				curStatusPtr->fogType = FOG_LINEAR;
 			} else {
 				FAIL("Unknown option");


### PR DESCRIPTION
This PR adds a correct support of the `ARB_fog_`* options in fragment shaders and a dummy support of `ARB_precision_hint_nicest`.