### PR TITLE
Make the ProgramStringARB fail when failed to convert/compile

### DIFF
--- a/src/gl/oldprogram.c
+++ b/src/gl/oldprogram.c
@@ -161,11 +161,17 @@ void gl4es_glProgramStringARB(GLenum target, GLenum format, GLsizei len, const G
     if (!old->shader->source) {
         DBG(printf("Error with ARB->GLSL conversion\n");)
         errorShim(GL_INVALID_OPERATION);
+        if (glstate->glsl->error_msg) free(glstate->glsl->error_msg);
+        glstate->glsl->error_msg = strdup("Error with ARB->GLSL conversion");
+        glstate->glsl->error_ptr = 0;
         return;
     }
     if (!old->shader->converted) {
         DBG(printf("Error with GLSL->GLSL:ES conversion\n");)
         errorShim(GL_INVALID_OPERATION);
+        if (glstate->glsl->error_msg) free(glstate->glsl->error_msg);
+        glstate->glsl->error_msg = strdup("Error with GLSL->GLSL:ES conversion");
+        glstate->glsl->error_ptr = 0;
         return;
     }
     gl4es_glCompileShader(old->shader->id);
@@ -174,6 +180,9 @@ void gl4es_glProgramStringARB(GLenum target, GLenum format, GLsizei len, const G
     if(res!=GL_TRUE) {
         DBG(printf("Error with Compile shader\n");)
         errorShim(GL_INVALID_OPERATION);
+        if (glstate->glsl->error_msg) free(glstate->glsl->error_msg);
+        glstate->glsl->error_msg = strdup("Error with Compile shader");
+        glstate->glsl->error_ptr = 0;
         return;
     }
 }


### PR DESCRIPTION
This PR fixes the behavior of gl_ProgramStringARB when gl4es fails to convert the GLSL code into a compiled shader by adding a dummy error at address 0 (beginning of shader).