### PR TITLE
cmake: Install lib and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,3 +234,10 @@ create_test(PointSprite pointsprite "0000248810" 20)
 
 create_test_GLES(OpenRA 2 openra "0000031249" 20 "638x478+1+1")
 create_test_GLES(GLSL_lighting 2 glsl_lighting "0000505393" 20)
+install(TARGETS GL
+  LIBRARY
+    DESTINATION "/usr/lib/gl4es/"
+  )
+install(DIRECTORY "include/"
+  DESTINATION "/usr/include/gl4es/"
+  )


### PR DESCRIPTION
Note files are installed into gl4es namespace to avoid overlap,
with system's opengl files.

This is useful for distro packagers

Signed-off-by: Philippe Coval <rzr@users.sf.net>
Change-Id: I3f2648b3c5da03693cf2a6bf47ae089bd207cee2