### PR TITLE
Fixed two errors

### DIFF
--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -2684,6 +2684,17 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, int *has
 					FAIL("Invalid state");
 				}
 				
+				if (curStatusPtr->curValue.newVar.state == 7) {
+					pushArray((sArray*)&curStatusPtr->curValue.newVar, strdup(","));
+					pushArray((sArray*)&curStatusPtr->curValue.newVar, strdup("0.0"));
+					curStatusPtr->curValue.newVar.state += 2;
+				}
+				if (curStatusPtr->curValue.newVar.state == 9) {
+					pushArray((sArray*)&curStatusPtr->curValue.newVar, strdup(","));
+					pushArray((sArray*)&curStatusPtr->curValue.newVar, strdup("0.0"));
+					curStatusPtr->curValue.newVar.state += 2;
+				}
+				
 				pushArray((sArray*)&curStatusPtr->curValue.newVar, getToken(curStatusPtr));
 				curStatusPtr->curValue.newVar.state = 12;
 				break;

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -2679,7 +2679,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, int *has
 				curStatusPtr->curValue.newVar.state = 4;
 				break;
 			case TOK_RBRACE:
-				if ((curStatusPtr->curValue.newVar.state != 5) && (curStatusPtr->curValue.newVar.state != 11)) {
+				if ((curStatusPtr->curValue.newVar.state != 5) && (curStatusPtr->curValue.newVar.state != 7)
+					&& (curStatusPtr->curValue.newVar.state != 9) && (curStatusPtr->curValue.newVar.state != 11)) {
 					FAIL("Invalid state");
 				}
 				
@@ -3561,6 +3562,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, int *has
 				/* FALLTHROUGH */
 			case STATE_AFTER_VALID:
 			case STATE_AFTER_VALID_RSQBR:
+			case STATE_AFTER_NUMBER:
 			case STATE_AFTER_SWIZZLE:
 				if (curStatusPtr->curToken == TOK_COMMA) {
 					curStatusPtr->curValue.newInst.state = STATE_START;


### PR DESCRIPTION
This PR fixes two errors:
- the first one is when having a constant inside an instruction (though it is *technically* not in the [official(?) documentation](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_fragment_program.txt));
- the second one is when trying to initialize a single-value parameter with two values.