### PR TITLE
ARB fixes

### DIFF
--- a/src/gl/arbhelper.h
+++ b/src/gl/arbhelper.h
@@ -21,11 +21,11 @@
 // ARBCONV_DBG - general ArbConverter debug logs
 #define ARBCONV_DBG(a) 
 // ARBCONV_DBG_LP - code loop ArbConverter debug logs
-#define ARBCONV_DBG_LP(a)
+#define ARBCONV_DBG_LP(a) 
 // ARBCONV_DBG_AS - reassembly loop (2nd loop) ArbConverter debug logs
-#define ARBCONV_DBG_AS(a)
+#define ARBCONV_DBG_AS(a) 
 // ARBCONV_DBG_HEAVY - heavy ArbConverter debug logs and operations (e.g. check for pointer correctness...)
-#define ARBCONV_DBG_HEAVY(a)
+#define ARBCONV_DBG_HEAVY(a) 
 #endif
 
 #ifdef MAX_TEX

--- a/src/gl/arbhelper.h
+++ b/src/gl/arbhelper.h
@@ -137,6 +137,7 @@ eInstruction STR2INST(char *str, int *sat);
 	ENUMVALUE2STR(vartype, VARTYPE_,TEMP) \
 	ENUMVALUE2STR(vartype, VARTYPE_,OUTPUT) \
 	ENUMVALUE2STR(vartype, VARTYPE_,CONST) \
+	ENUMVALUE2STR(vartype, VARTYPE_,PSEUDOCONST) \
 	"???")
 #define INST2STR(inst) ( \
 	ENUMVALUE2STR(inst, INST_,ABS) ENUMVALUE2STR(inst, INST_,ADD) \

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -7,12 +7,18 @@
 #include "../config.h"
 
 // ARBCONV_DBG_RE - resolve* error ArbConverter debug logs
+#ifdef DEBUG
 #define ARBCONV_DBG_RE(...) printf(__VA_ARGS__);
+#else
+#define ARBCONV_DBG_RE(...)
+#endif
 
-#define IS_SWIZZLE(str) (((str)[0] >= 'w') && ((str)[0] <= 'z') && \
- (((str)[1] == '\0') || (((str)[1] >= 'w') && ((str)[1] <= 'z') && \
- (((str)[2] == '\0') || (((str)[2] >= 'w') && ((str)[2] <= 'z') && \
- (((str)[3] == '\0') || (((str)[3] >= 'w') && ((str)[3] <= 'z') && \
+#define IS_SWIZ_VALUE(v) ((((v) >= 'w') && ((v) <= 'z')) || \
+  ((v) == 'r') || ((v) == 'g') || ((v) == 'b') || ((v) == 'a'))
+#define IS_SWIZZLE(str) (IS_SWIZ_VALUE((str)[0]) && \
+ (((str)[1] == '\0') || (IS_SWIZ_VALUE((str)[1]) && \
+ (((str)[2] == '\0') || (IS_SWIZ_VALUE((str)[2]) && \
+ (((str)[3] == '\0') || (IS_SWIZ_VALUE((str)[3]) && \
   ((str)[4] == '\0'))))))))
 #define IS_NEW_STR_OR_SWIZZLE(str, t) (((str)[0] == ',') || ((t == 1) && IS_SWIZZLE(str)))
 #define IS_NONE_OR_SWIZZLE (!newVar->strLen || IS_SWIZZLE(newVar->strParts[0]))

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -1401,6 +1401,8 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 			return NULL;
 		}
 	} else if (tok[0] == '{') {
+		int valuesCnt = 0;
+		
 		sCurStatus pseudoSt;
 		pseudoSt.curValue.newVar.state = 0;
 		pseudoSt.status = ST_VARIABLE_INIT;
@@ -1441,6 +1443,7 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 					pseudoSt.status = ST_ERROR;
 					continue;
 				}
+				++valuesCnt;
 				pseudoSt.curValue.newVar.state = 3*(pseudoSt.curValue.newVar.state / 3) + 2;
 				break;
 				
@@ -1490,7 +1493,9 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 			return NULL;
 		}
 		
-		if (appendString(&pseudoSt, ")", 1)) {
+		if (((((valuesCnt != 1) && (valuesCnt != 4))) || appendString(&pseudoSt, ")", 1))
+		  && ( (valuesCnt != 2)                       || appendString(&pseudoSt, ", 0., 0.)", 9))
+		  && ( (valuesCnt != 3)                       || appendString(&pseudoSt, ", 0.)", 5))) {
 			free(pseudoSt.outputString);
 			ARBCONV_DBG_RE("Failed to get param: not enough memory?\n")
 			return NULL;
@@ -1606,7 +1611,7 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 	 \ ? "state" "." "matrix" "." "program" "[" <stateProgramMatNum> "]" "." "invtrans" "." "row" "[" <stateMatrixRowNum> "]"
 	 \ V "program" "." "env" "[" <progEnvParamNum> "]"
 	 \ V "program" "." "local" "[" <progLocalParamNum> "]"
-	 \ * <optionalSign> <floatConstant>
+	 \ V <optionalSign> <floatConstant>
 	 \ V "{" <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"
@@ -1866,7 +1871,7 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 	 \ V "program" "." "env" "[" <progEnvParamNum> ".." <progEnvParamNum> "]"
 	 \ V "program" "." "local" "[" <progLocalParamNum> "]"
 	 \ V "program" "." "local" "[" <progLocalParamNum> ".." <progLocalParamNum> "]"
-	 \ * <optionalSign> <floatConstant>
+	 \ V <optionalSign> <floatConstant>
 	 \ V "{" <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"
@@ -1978,7 +1983,7 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 	 \ ? "state" "." "matrix" "." "program" "[" <stateProgramMatNum> "]" "." "invtrans" "." "row" "[" <stateMatrixRowNum> "]"
 	 \ V "program" "." "env" "[" <progEnvParamNum> "]"
 	 \ V "program" "." "local" "[" <progLocalParamNum> "]"
-	 \ * <optionalSign> <floatConstant>
+	 \ V <optionalSign> <floatConstant>
 	 \ V "{" <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"
@@ -2206,7 +2211,7 @@ char **resolveParam(sCurStatus_NewVar *newVar, int vertex, int type) {
 	 \ V "program" "." "env" "[" <progEnvParamNum> ".." <progEnvParamNum> "]"
 	 \ V "program" "." "local" "[" <progLocalParamNum> "]"
 	 \ V "program" "." "local" "[" <progLocalParamNum> ".." <progLocalParamNum> "]"
-	 \ * <optionalSign> <floatConstant>
+	 \ V <optionalSign> <floatConstant>
 	 \ V "{" <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"
 	 \ V "{" <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "," <optionalSign> <floatConstant> "}"

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -3133,8 +3133,15 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, int *has
 			}
 			
 			sVariable *var = kh_val(curStatusPtr->varsMap, varIdx);
-			
 			pushArray((sArray*)var, curStatusPtr->curValue.string);
+			
+			int ret;
+			varIdx = kh_put(variables, curStatusPtr->varsMap, curStatusPtr->curValue.string, &ret);
+			if (ret < 0) {
+				FAIL("Unknown error");
+			}
+			kh_val(curStatusPtr->varsMap, varIdx) = var;
+			
 			curStatusPtr->valueType = TYPE_NONE;
 			break;
 			


### PR DESCRIPTION
This PR fixes some problems in the ARB generator:
- when debugging, the `PSEUDOCONST` variable type is not recognized
- `rgba`-type swizzles are not recognized by the `IS_SWIZZLE` macro
- param `{0.3, 0.2, 0.1}` will generate `vec4(0.3, 0.2, 0.1)` (which is invalid)
- when aliasing, the new alias is not put in the name -> `variable` struct map
- minor cosmetic updates