### PR TITLE
Fixed gl_FragDepth in the ARB converter

### DIFF
--- a/src/gl/arbparser.h
+++ b/src/gl/arbparser.h
@@ -5,7 +5,12 @@
 
 #include "arbhelper.h"
 
+struct sSpecialCases {
+	int hasFogFragCoord;
+	int isDepthReplacing;
+};
+
 eToken readNextToken(sCurStatus* curStatus);
-void parseToken(sCurStatus *curStatus, int vertex, char **error_msg, int *hasFogFragCoord);
+void parseToken(sCurStatus *curStatus, int vertex, char **error_msg, struct sSpecialCases *hasFogFragCoord);
 
 #endif // _GL4ES_ARBPARSER_H_


### PR DESCRIPTION
This PR fixes the `result.depth` fragment ARB variable, that should be mapped to the `(*, *, gl_FragDepth, *)` vector (and adds scalability of such special cases).