### PR TITLE
Fix of the preprocessor with exponential notation

### DIFF
--- a/src/gl/preproc.c
+++ b/src/gl/preproc.c
@@ -223,7 +223,7 @@ eTokenType NextToken(char **p, uToken *tok) {
                             (*p)++; nextc=**p;
                         }
                         while(nextc>='0' && nextc<='9') { nb=nb*10+nextc-'0'; (*p)++; nextc=**p;}
-                        fnb=powf(fnb, nb*expsign);
+                        fnb *= powf(10, nb*expsign); // exp10f is a GNU extension
                     }
                     if(nextc=='f') {
                         (*p)++; nextc=**p;


### PR DESCRIPTION
This PR fixes the preprocessor with numbers such as `1e10` (#213 and #215).