### PR TITLE
Fix crash on unload with NO_INIT_CONSTRUCTOR

### DIFF
--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -668,7 +668,11 @@ void initialize_gl4es() {
 #ifndef NOX11
 void FreeFBVisual();
 #endif
+#ifdef NO_INIT_CONSTRUCTOR
+__attribute__((visibility("default")))
+#else
 __attribute__((destructor))
+#endif
 void close_gl4es() {
 		#ifdef GL4ES_COMPILE_FOR_USE_IN_SHARED_LIB
 	    SHUT_LOGD("Shuting down request\n");


### PR DESCRIPTION
Better solution to https://github.com/FWGS/xash3d-fwgs/pull/255