### PR TITLE
Fixup public functions

### DIFF
--- a/include/gl4esinit.h
+++ b/include/gl4esinit.h
@@ -2,12 +2,23 @@
 #ifndef _GL4ESINCLUDE_INIT_H_
 #define _GL4ESINCLUDE_INIT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // set driver GetProcAddress implementation. required for hardext detection with NOEGL or when loader is disabled
 void set_getprocaddress(void *(*new_proc_address)(const char *));
 // reguired with NOEGL
 void set_getmainfbsize(void (*new_getMainFBSize)(int* width, int* height));
-// do this before any GL calls if init constructors disabled
+// do this before any GL calls if init constructors are disabled.
 void initialize_gl4es(void);
+// do this to uninitialize GL4ES if init constructors are disabled.
+void close_gl4es();
 // wrapped GetProcAddress
 void *gl4es_GetProcAddress(const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/src/gl/gl_lookup.c
+++ b/src/gl/gl_lookup.c
@@ -28,6 +28,7 @@ void gl4es_Stub(void *x, ...) {
     return;
 }
 
+__attribute__((visibility("default")))
 void *gl4es_GetProcAddress(const char *name) {
     DBG(printf("glGetProcAddress(\"%s\")", name);)
     // generated gles wrappers

--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -52,10 +52,12 @@ void glx_init();
 
 static int inited = 0;
 
+__attribute__((visibility("default")))
 void set_getmainfbsize(void (*new_getMainFBSize)(int* w, int* h)) {
     gl4es_getMainFBSize = (void*)new_getMainFBSize;
 }
 
+__attribute__((visibility("default")))
 void set_getprocaddress(void *(*new_proc_address)(const char *)) {
     gles_getProcAddress = new_proc_address;
 }


### PR DESCRIPTION
1. Add `__attribute__((visibility("default")))` to all public functions.
2. Expose `close_gl4es()`.
3. Make public header C++-compatible.