### PR TITLE
[GLSL ES 300] Add macros for GLSL compatibility

### DIFF
--- a/src/gl/shaderconv.c
+++ b/src/gl/shaderconv.c
@@ -285,8 +285,8 @@ static const char* gl_TexMatrixSources[] = {
 static const char* GLESHeader[] = {
   "#version 100\n%sprecision %s float;\nprecision %s int;\n",
   "#version 120\n%sprecision %s float;\nprecision %s int;\n",
-  "#version 310 es\n%sprecision %s float;\nprecision %s int;\n",
-  "#version 300 es\n%sprecision %s float;\nprecision %s int;\n"
+  "#version 310 es\n#define attribute in\n#define varying out\n%sprecision %s float;\nprecision %s int;\n",
+  "#version 300 es\n#define attribute in\n#define varying out\n%sprecision %s float;\nprecision %s int;\n"
 };
 
 static const char* gl4es_transpose =


### PR DESCRIPTION
I've noticed that converting GLSL 1.20 to GLSL ES 300+, does not convert `attribute` and `varying`, it caused these compile errors:
```
'attribute' : Illegal use of reserved word
'varying': Illegal use of reserved word
```
So, I added macros to automatically replace them to `in` and `out`.