### PR TITLE
fix some warnerr from clang12. Also fix some small errors (thanks cla…

### DIFF
--- a/src/gl/arbgenerator.c
+++ b/src/gl/arbgenerator.c
@@ -57,7 +57,7 @@ void generateVariablePre(sCurStatus *curStatusPtr, int vertex, char **error_msg,
 			}
 		} else {
 			for (size_t i = 0; i < varPtr->init.strings_count; ++i) {
-				sprintf(buf, "%ld", i);
+				sprintf(buf, "%zd", i);
 				APPEND_OUTPUT("\t", 1)
 				APPEND_OUTPUT2(varPtr->names[0])
 				APPEND_OUTPUT("[", 1)

--- a/src/gl/buffers.c
+++ b/src/gl/buffers.c
@@ -64,9 +64,9 @@ glbuffer_t* getbuffer_buffer(GLenum target) {
 glbuffer_t* getbuffer_id(GLuint buffer) {
     if(!buffer)
         return NULL;
-   	khint_t k;
-   	int ret;
-	khash_t(buff) *list = glstate->buffers;
+    khint_t k;
+    int ret;
+    khash_t(buff) *list = glstate->buffers;
     k = kh_get(buff, list, buffer);
     if (k == kh_end(list))
         return NULL;
@@ -437,8 +437,8 @@ void *gl4es_glMapBuffer(GLenum target, GLenum access) {
     if(target==GL_ARRAY_BUFFER)
         VaoSharedClear(glstate->vao);
 
-	glbuffer_t *buff = getbuffer_buffer(target);
-	if (buff==NULL) {
+    glbuffer_t *buff = getbuffer_buffer(target);
+    if (buff==NULL) {
         errorShim(GL_INVALID_VALUE);
 		return NULL;
     }
@@ -484,8 +484,8 @@ GLboolean gl4es_glUnmapBuffer(GLenum target) {
     if(target==GL_ARRAY_BUFFER)
         VaoSharedClear(glstate->vao);
         
-	glbuffer_t *buff = getbuffer_buffer(target);
-	if (buff==NULL) {
+    glbuffer_t *buff = getbuffer_buffer(target);
+    if (buff==NULL) {
         errorShim(GL_INVALID_VALUE);
 		return GL_FALSE;
     }
@@ -635,7 +635,7 @@ void gl4es_glFlushMappedBufferRange(GLenum target, GLintptr offset, GLsizeiptr l
     if(target==GL_ARRAY_BUFFER)
         VaoSharedClear(glstate->vao);
 
-	glbuffer_t *buff = getbuffer_buffer(target);
+    glbuffer_t *buff = getbuffer_buffer(target);
     if(!buff) {
         errorShim(GL_INVALID_VALUE);
         return;

--- a/src/gl/drawing.c
+++ b/src/gl/drawing.c
@@ -40,7 +40,7 @@ static GLboolean is_cache_compatible(GLsizei count) {
     return GL_TRUE;
 }
 
-static GLboolean is_list_compatible(renderlist_t* list) {
+GLboolean is_list_compatible(renderlist_t* list) {
     #define T2(AA, A, B) \
     if(glstate->vao->AA!=(list->B!=NULL)) return GL_FALSE;
     #define TEST(A,B) T2(vertexattrib[A].enabled, A, B)
@@ -62,8 +62,8 @@ static GLboolean is_list_compatible(renderlist_t* list) {
     return GL_TRUE;
 }
 
-static renderlist_t *arrays_to_renderlist(renderlist_t *list, GLenum mode,
-                                        GLsizei skip, GLsizei count) {
+renderlist_t *arrays_to_renderlist(renderlist_t *list, GLenum mode,
+                                   GLsizei skip, GLsizei count) {
     if (! list)
         list = alloc_renderlist();
     DBG(LOGD("arrary_to_renderlist, compiling=%d, skip=%d, count=%d\n", glstate->list.compiling, skip, count);)
@@ -142,7 +142,7 @@ static renderlist_t *arrays_to_renderlist(renderlist_t *list, GLenum mode,
                     glstate->vao->secondary.ptr = copy_gl_pointer_color_bgra(glstate->vao->vertexattrib[ATT_SECONDARY].pointer, glstate->vao->vertexattrib[ATT_SECONDARY].stride, 4, 0, count);
                 else
                     glstate->vao->secondary.ptr = copy_gl_pointer(&glstate->vao->vertexattrib[ATT_SECONDARY], 4, 0, count);		// alpha chanel is always 0 for secondary...
-                    list->secondary = glstate->vao->secondary.ptr + 4*skip;
+                list->secondary = glstate->vao->secondary.ptr + 4*skip;
             } else {
                 if(glstate->vao->vertexattrib[ATT_SECONDARY].size==GL_BGRA)
                     list->secondary = copy_gl_pointer_color_bgra(glstate->vao->vertexattrib[ATT_SECONDARY].pointer, glstate->vao->vertexattrib[ATT_SECONDARY].stride, 4, skip, count);

--- a/src/gl/framebuffers.c
+++ b/src/gl/framebuffers.c
@@ -1437,7 +1437,7 @@ void gl4es_glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1,
     float zoomx = ((float)(dstX1-dstX0))/srcW;
     float zoomy = ((float)(dstY1-dstY0))/srcH;
     // get the width / height of write FBO
-    int fbowidth, fboheight;
+    int fbowidth = 0, fboheight = 0;
     int blitfullscreen = 0;
     if(glstate->fbo.fbo_draw->id==0/* && glstate->fbo.mainfbo_fbo*/) {
         if(globals4es.blitfb0/* || (globals4es.usefb && !globals4es.usefbo)*/)

--- a/src/gl/gl4es.c
+++ b/src/gl/gl4es.c
@@ -976,17 +976,17 @@ void gl4es_glPolygonMode(GLenum face, GLenum mode) {
             return;
         }
         else gl4es_flush();
-	switch(mode) {
-		case GL_LINE:
-		case GL_POINT:
-			glstate->polygon_mode = mode;
-			break;
-		case GL_FILL:
-			glstate->polygon_mode = 0;
-			break;
-		default:
-			glstate->polygon_mode = 0;
-	}
+    switch(mode) {
+	case GL_LINE:
+	case GL_POINT:
+		glstate->polygon_mode = mode;
+		break;
+	case GL_FILL:
+		glstate->polygon_mode = 0;
+		break;
+	default:
+		glstate->polygon_mode = 0;
+    }
 }
 void glPolygonMode(GLenum face, GLenum mode) AliasExport("gl4es_glPolygonMode");
 

--- a/src/gl/glstate.c
+++ b/src/gl/glstate.c
@@ -108,9 +108,9 @@ void* NewGLState(void* shared_glstate, int es2only) {
     for (int i=0; i<MAX_TEX; ++i)
         glstate->texcoord[i] = glstate->vavalue[ATT_MULTITEXCOORD0+i];
     // set specifics default
-	GLfloat white[] = {1.0f, 1.0f, 1.0f, 1.0f};
-	memcpy(glstate->color, white, sizeof(GLfloat)*4);
-	glstate->shim_error = GL_NO_ERROR;
+    GLfloat white[] = {1.0f, 1.0f, 1.0f, 1.0f};
+    memcpy(glstate->color, white, sizeof(GLfloat)*4);
+    glstate->shim_error = GL_NO_ERROR;
     glstate->normal[2] = 1.0f; // default normal is 0/0/1
     glstate->matrix_mode = GL_MODELVIEW;
     

--- a/src/gl/list.c
+++ b/src/gl/list.c
@@ -838,9 +838,9 @@ void adjust_renderlist(renderlist_t *list) {
         if (list->set_texture && (list->tmu == a))
             bound = gl4es_getTexture(list->target_texture, list->texture);
 	    // GL_ARB_texture_rectangle
-	    if ((list->tex[a]) && (itarget == ENABLED_TEXTURE_RECTANGLE) && (bound)) {
-		    tex_coord_rect_arb(list->tex[a], list->tex_stride[a]>>2, list->len, bound->width, bound->height);
-	    }
+	if ((list->tex[a]) && (itarget == ENABLED_TEXTURE_RECTANGLE) && (bound)) {
+	    tex_coord_rect_arb(list->tex[a], list->tex_stride[a]>>2, list->len, bound->width, bound->height);
+	}
     }
 }
 

--- a/src/gl/math/matheval.c
+++ b/src/gl/math/matheval.c
@@ -219,65 +219,65 @@ _math_de_casteljau_surf(GLfloat * cn, GLfloat * out, GLfloat * du,
                 out[k] = us * (vs * CN(0, 0, k) + v * CN(0, 1, k)) +
                     u * (vs * CN(1, 0, k) + v * CN(1, 1, k));
             }
-    } else if (minorder == uorder) {
-        for (k = 0; k < dim; k++) {
-            /* bilinear de Casteljau step */
-            DCN(1, 0) = CN(1, 0, k) - CN(0, 0, k);
-            DCN(0, 0) = us * CN(0, 0, k) + u * CN(1, 0, k);
+        } else if (minorder == uorder) {
+            for (k = 0; k < dim; k++) {
+                /* bilinear de Casteljau step */
+                DCN(1, 0) = CN(1, 0, k) - CN(0, 0, k);
+                DCN(0, 0) = us * CN(0, 0, k) + u * CN(1, 0, k);
 
-            for (j = 0; j < vorder - 1; j++) {
-                /* for the derivative in u */
-                DCN(1, j + 1) = CN(1, j + 1, k) - CN(0, j + 1, k);
-                DCN(1, j) = vs * DCN(1, j) + v * DCN(1, j + 1);
+                for (j = 0; j < vorder - 1; j++) {
+                    /* for the derivative in u */
+                    DCN(1, j + 1) = CN(1, j + 1, k) - CN(0, j + 1, k);
+                    DCN(1, j) = vs * DCN(1, j) + v * DCN(1, j + 1);
 
-                /* for the `point' */
-                DCN(0, j + 1) = us * CN(0, j + 1, k) + u * CN(1, j + 1, k);
-                DCN(0, j) = vs * DCN(0, j) + v * DCN(0, j + 1);
-            }
-
-            /* remaining linear de Casteljau steps until the second last step */
-            for (h = minorder; h < vorder - 1; h++)
-                for (j = 0; j < vorder - h; j++) {
-                /* for the derivative in u */
-                DCN(1, j) = vs * DCN(1, j) + v * DCN(1, j + 1);
-
-                /* for the `point' */
-                DCN(0, j) = vs * DCN(0, j) + v * DCN(0, j + 1);
-            }
-
-            /* derivative direction in v */
-            dv[k] = DCN(0, 1) - DCN(0, 0);
-
-            /* derivative direction in u */
-            du[k] = vs * DCN(1, 0) + v * DCN(1, 1);
-
-            /* last linear de Casteljau step */
-            out[k] = vs * DCN(0, 0) + v * DCN(0, 1);
-        }
-    } else {  /* minorder == vorder */
-        for (k = 0; k < dim; k++) {
-            /* bilinear de Casteljau step */
-            DCN(0, 1) = CN(0, 1, k) - CN(0, 0, k);
-            DCN(0, 0) = vs * CN(0, 0, k) + v * CN(0, 1, k);
-            for (i = 0; i < uorder - 1; i++) {
-                /* for the derivative in v */
-                DCN(i + 1, 1) = CN(i + 1, 1, k) - CN(i + 1, 0, k);
-                DCN(i, 1) = us * DCN(i, 1) + u * DCN(i + 1, 1);
-
-                /* for the `point' */
-                DCN(i + 1, 0) = vs * CN(i + 1, 0, k) + v * CN(i + 1, 1, k);
-                DCN(i, 0) = us * DCN(i, 0) + u * DCN(i + 1, 0);
-            }
-
-            /* remaining linear de Casteljau steps until the second last step */
-            for (h = minorder; h < uorder - 1; h++)
-                for (i = 0; i < uorder - h; i++) {
-                /* for the derivative in v */
-                DCN(i, 1) = us * DCN(i, 1) + u * DCN(i + 1, 1);
-
-                /* for the `point' */
-                DCN(i, 0) = us * DCN(i, 0) + u * DCN(i + 1, 0);
+                    /* for the `point' */
+                    DCN(0, j + 1) = us * CN(0, j + 1, k) + u * CN(1, j + 1, k);
+                    DCN(0, j) = vs * DCN(0, j) + v * DCN(0, j + 1);
                 }
+
+                /* remaining linear de Casteljau steps until the second last step */
+                for (h = minorder; h < vorder - 1; h++)
+                    for (j = 0; j < vorder - h; j++) {
+                        /* for the derivative in u */
+                        DCN(1, j) = vs * DCN(1, j) + v * DCN(1, j + 1);
+
+                        /* for the `point' */
+                        DCN(0, j) = vs * DCN(0, j) + v * DCN(0, j + 1);
+                    }
+
+                /* derivative direction in v */
+                dv[k] = DCN(0, 1) - DCN(0, 0);
+
+                /* derivative direction in u */
+                du[k] = vs * DCN(1, 0) + v * DCN(1, 1);
+
+                /* last linear de Casteljau step */
+                out[k] = vs * DCN(0, 0) + v * DCN(0, 1);
+            }
+        } else {  /* minorder == vorder */
+            for (k = 0; k < dim; k++) {
+                /* bilinear de Casteljau step */
+                DCN(0, 1) = CN(0, 1, k) - CN(0, 0, k);
+                DCN(0, 0) = vs * CN(0, 0, k) + v * CN(0, 1, k);
+                for (i = 0; i < uorder - 1; i++) {
+                    /* for the derivative in v */
+                    DCN(i + 1, 1) = CN(i + 1, 1, k) - CN(i + 1, 0, k);
+                    DCN(i, 1) = us * DCN(i, 1) + u * DCN(i + 1, 1);
+
+                    /* for the `point' */
+                    DCN(i + 1, 0) = vs * CN(i + 1, 0, k) + v * CN(i + 1, 1, k);
+                    DCN(i, 0) = us * DCN(i, 0) + u * DCN(i + 1, 0);
+                }
+
+                /* remaining linear de Casteljau steps until the second last step */
+                for (h = minorder; h < uorder - 1; h++)
+                    for (i = 0; i < uorder - h; i++) {
+                        /* for the derivative in v */
+                        DCN(i, 1) = us * DCN(i, 1) + u * DCN(i + 1, 1);
+
+                        /* for the `point' */
+                        DCN(i, 0) = us * DCN(i, 0) + u * DCN(i + 1, 0);
+                    }
 
                 /* derivative direction in u */
                 du[k] = DCN(1, 0) - DCN(0, 0);
@@ -361,7 +361,7 @@ _math_de_casteljau_surf(GLfloat * cn, GLfloat * out, GLfloat * du,
                 for (j = 0; j < vorder - h; j++) {
                     /* for the derivative in u */
                     DCN(2, j) = vs * DCN(2, j) + v * DCN(2, j + 1);
-        
+
                     /* for the `point' */
                     DCN(0, j) = vs * DCN(0, j) + v * DCN(0, j + 1);
                 }

--- a/src/gl/raster.c
+++ b/src/gl/raster.c
@@ -11,33 +11,35 @@
 #include "matvec.h"
 #include "pixel.h"
 
+#undef min
+#undef max
 #define min(a, b)	((a)<b)?(a):(b)
 #define max(a, b)	((a)>(b))?(a):(b)
 
 void gl4es_glRasterPos3f(GLfloat x, GLfloat y, GLfloat z) {
     if (glstate->list.active)
         if (glstate->list.compiling) {
-			NewStage(glstate->list.active, STAGE_RASTER);
-			rlRasterOp(glstate->list.active, 1, x, y, z);
-			noerrorShim();
-			return;
-		} else gl4es_flush();
+		NewStage(glstate->list.active, STAGE_RASTER);
+		rlRasterOp(glstate->list.active, 1, x, y, z);
+		noerrorShim();
+		return;
+	} else gl4es_flush();
 
-	// Transform xyz coordinates with current modelview and projection matrix...
-	GLfloat glmatrix[16], projection[16], modelview[16];
-	GLfloat t[4], transl[4] = {x, y, z, 1.0f};
-	gl4es_glGetFloatv(GL_PROJECTION_MATRIX, glmatrix);
-	matrix_transpose(glmatrix, projection);
-	gl4es_glGetFloatv(GL_MODELVIEW_MATRIX, glmatrix);
-	matrix_transpose(glmatrix, modelview);
-	matrix_vector(modelview, transl, t);
-	matrix_vector(projection, t, transl);
-	GLfloat w2, h2;
-	w2=glstate->raster.viewport.width/2.0f;
-	h2=glstate->raster.viewport.height/2.0f;
-	glstate->raster.rPos.x = transl[0]*w2+w2;
-	glstate->raster.rPos.y = transl[1]*h2+h2;
-	glstate->raster.rPos.z = transl[2];
+    // Transform xyz coordinates with current modelview and projection matrix...
+    GLfloat glmatrix[16], projection[16], modelview[16];
+    GLfloat t[4], transl[4] = {x, y, z, 1.0f};
+    gl4es_glGetFloatv(GL_PROJECTION_MATRIX, glmatrix);
+    matrix_transpose(glmatrix, projection);
+    gl4es_glGetFloatv(GL_MODELVIEW_MATRIX, glmatrix);
+    matrix_transpose(glmatrix, modelview);
+    matrix_vector(modelview, transl, t);
+    matrix_vector(projection, t, transl);
+    GLfloat w2, h2;
+    w2=glstate->raster.viewport.width/2.0f;
+    h2=glstate->raster.viewport.height/2.0f;
+    glstate->raster.rPos.x = transl[0]*w2+w2;
+    glstate->raster.rPos.y = transl[1]*h2+h2;
+    glstate->raster.rPos.z = transl[2];
 }
 #if !defined(NO_EGL) && !defined(NOX11)
 void refreshMainFBO();
@@ -120,57 +122,57 @@ void popViewport() {
 void gl4es_glPixelZoom(GLfloat xfactor, GLfloat yfactor) {
     if (glstate->list.active)
         if (glstate->list.compiling) {
-			NewStage(glstate->list.active, STAGE_RASTER);
-			rlRasterOp(glstate->list.active, 3, xfactor, yfactor, 0.0f);
-			noerrorShim();
-			return;
-		} else gl4es_flush();
+		NewStage(glstate->list.active, STAGE_RASTER);
+		rlRasterOp(glstate->list.active, 3, xfactor, yfactor, 0.0f);
+		noerrorShim();
+		return;
+	} else gl4es_flush();
 
-	glstate->raster.raster_zoomx = xfactor;
-	glstate->raster.raster_zoomy = yfactor;
+    glstate->raster.raster_zoomx = xfactor;
+    glstate->raster.raster_zoomy = yfactor;
 //printf("LIBGL: glPixelZoom(%f, %f)\n", xfactor, yfactor);
 }
 
 void gl4es_glPixelTransferf(GLenum pname, GLfloat param) {
     if (glstate->list.active)
         if (glstate->list.compiling) {
-			NewStage(glstate->list.active, STAGE_RASTER);
-			rlRasterOp(glstate->list.active, pname|0x10000, param, 0.0f, 0.0f);
-			noerrorShim();
-			return;
-		} else gl4es_flush();
+		NewStage(glstate->list.active, STAGE_RASTER);
+		rlRasterOp(glstate->list.active, pname|0x10000, param, 0.0f, 0.0f);
+		noerrorShim();
+		return;
+	} else gl4es_flush();
 
 //printf("LIBGL: glPixelTransferf(%04x, %f)\n", pname, param);
-	switch(pname) {
-		case GL_RED_SCALE:
-			glstate->raster.raster_scale[0]=param;
-			break;
-		case GL_RED_BIAS:
-			glstate->raster.raster_bias[0]=param;
-			break;
-		case GL_GREEN_SCALE:
-		case GL_BLUE_SCALE:
-		case GL_ALPHA_SCALE:
-			glstate->raster.raster_scale[(pname-GL_GREEN_SCALE)/2+1]=param;
-			break;
-		case GL_GREEN_BIAS:
-		case GL_BLUE_BIAS:
-		case GL_ALPHA_BIAS:
-			glstate->raster.raster_bias[(pname-GL_GREEN_BIAS)/2+1]=param;
-			break;
-		case GL_INDEX_SHIFT:
-			glstate->raster.index_shift=param;
-			break;
-		case GL_INDEX_OFFSET:
-			glstate->raster.index_offset=param;
-			break;
-		case GL_MAP_COLOR:
-			glstate->raster.map_color=param?1:0;
-			break;
-		/*default:
-			printf("LIBGL: stubbed glPixelTransferf(%04x, %f)\n", pname, param);*/
+    switch(pname) {
+	case GL_RED_SCALE:
+		glstate->raster.raster_scale[0]=param;
+		break;
+	case GL_RED_BIAS:
+		glstate->raster.raster_bias[0]=param;
+		break;
+	case GL_GREEN_SCALE:
+	case GL_BLUE_SCALE:
+	case GL_ALPHA_SCALE:
+		glstate->raster.raster_scale[(pname-GL_GREEN_SCALE)/2+1]=param;
+		break;
+	case GL_GREEN_BIAS:
+	case GL_BLUE_BIAS:
+	case GL_ALPHA_BIAS:
+		glstate->raster.raster_bias[(pname-GL_GREEN_BIAS)/2+1]=param;
+		break;
+	case GL_INDEX_SHIFT:
+		glstate->raster.index_shift=param;
+		break;
+	case GL_INDEX_OFFSET:
+		glstate->raster.index_offset=param;
+		break;
+	case GL_MAP_COLOR:
+		glstate->raster.map_color=param?1:0;
+		break;
+	/*default:
+		printf("LIBGL: stubbed glPixelTransferf(%04x, %f)\n", pname, param);*/
 	// the other...
-	}
+    }
 }
 
 

--- a/src/gl/render.c
+++ b/src/gl/render.c
@@ -139,7 +139,7 @@ void gl4es_glLoadName(GLuint name) {
     push_hit();
     if (glstate->namestack.top == 0)
         return;
-	glstate->namestack.names[glstate->namestack.top-1] = name;
+    glstate->namestack.names[glstate->namestack.top-1] = name;
 }
 
 void gl4es_glSelectBuffer(GLsizei size, GLuint *buffer) {
@@ -415,11 +415,12 @@ void select_glDrawElements(const vertexattrib_t* vtx, GLenum mode, GLuint count,
 					break;
 				case GL_TRIANGLE_FAN:
 					if (i>1) {
-						if (select_triangle_in_viewscreen(vert+sind[0]*4, vert+sind[(i-1)]*4, vert+sind[i]*4))
+						if (select_triangle_in_viewscreen(vert+sind[0]*4, vert+sind[(i-1)]*4, vert+sind[i]*4)) {
 							ZMinMax(&zmin, &zmax, vert+sind[0]*4);
 							ZMinMax(&zmin, &zmax, vert+sind[i-1]*4);
 							ZMinMax(&zmin, &zmax, vert+sind[i]*4);
 							FOUND();
+						}	
 					}
 					break;
 				default:
@@ -476,11 +477,12 @@ void select_glDrawElements(const vertexattrib_t* vtx, GLenum mode, GLuint count,
 					break;
 				case GL_TRIANGLE_FAN:
 					if (i>1) {
-						if (select_triangle_in_viewscreen(vert+iind[0]*4, vert+iind[(i-1)]*4, vert+iind[i]*4))
+						if (select_triangle_in_viewscreen(vert+iind[0]*4, vert+iind[(i-1)]*4, vert+iind[i]*4)) {
 							ZMinMax(&zmin, &zmax, vert+iind[0]*4);
 							ZMinMax(&zmin, &zmax, vert+iind[i-1]*4);
 							ZMinMax(&zmin, &zmax, vert+iind[i]*4);
 							FOUND();
+						}
 					}
 					break;
 				default:

--- a/src/gl/shaderconv.c
+++ b/src/gl/shaderconv.c
@@ -679,7 +679,7 @@ char* ConvertShader(const char* pEntry, int isVertex, shaderconv_need_t *need)
           state = 0; // separator
         else      
           state = 3;
-          break;
+        break;
     }
     newptr++;
   }

--- a/src/gl/texture.c
+++ b/src/gl/texture.c
@@ -1174,11 +1174,11 @@ void gl4es_glTexImage2D(GLenum target, GLint level, GLint internalformat,
                     if(toshrink==1) {
                         pixel_halfscale(pixels, &out, width, height, format, type);
                         if(!bound->valid)
-                            bound->ratiox *= 0.5f; bound->ratioy *= 0.5f;
+                            { bound->ratiox *= 0.5f; bound->ratioy *= 0.5f; }
                     } else {
                         pixel_quarterscale(pixels, &out, width, height, format, type);
                         if(!bound->valid)
-                            bound->ratiox *= 0.25f; bound->ratioy *= 0.25f;
+                            { bound->ratiox *= 0.25f; bound->ratioy *= 0.25f; }
                     }
                     if (out != pixels && pixels!=datab)
                         free(pixels);

--- a/src/gl/texture_params.c
+++ b/src/gl/texture_params.c
@@ -88,7 +88,7 @@ void tex_coord_matrix(GLfloat *tex, GLsizei len, const GLfloat* mat) {
  * Apply texture matrix if not identity 
  * Or some NPOT texture used
  */
-int inline tex_setup_needchange(GLuint itarget) {
+int tex_setup_needchange(GLuint itarget) {
     if(hardext.esversion>1) return 0; // no text ajustement on ES2
 
     GLuint texunit = glstate->texture.client;


### PR DESCRIPTION
…ng).
-----
  When troubleshooting the 'misleading indentation' diagnostics, it was mostly just adding/removing spaces.
  However, in 2 files, the writing style "hinted" at the lost blocks ({}), which were added. Please check if they are needed in
    gl/texture.c (line 1177 and 1181)
    gl/render.c (line 418, 480)

And also blocks were NOT added (only spaces changed) in
    gl/math/matheval.c
although "in style", perhaps, there was also a "lost" block - it would be nice that you looked over.

Regargds,