### PR TITLE
1. Alternate Windows ES Emulator (PVRVFrame) also used DirectX -- tri…

### DIFF
--- a/src/gl/gl4es.c
+++ b/src/gl/gl4es.c
@@ -1,8 +1,14 @@
 #include "gl4es.h"
 
-#if defined(AMIGAOS4) || (defined(NOX11) && defined(NOEGL) && !defined(_WIN32))
+#ifdef _WIN32
+#ifdef _MSC_VER
+#pragma warning(disable : 4028 4133)
+#endif
+__declspec(dllimport)
+void __stdcall GetSystemTimeAsFileTime(unsigned __int64*);
+#elif defined(AMIGAOS4) || (defined(NOX11) && defined(NOEGL))
 #include <sys/time.h>
-#endif // defined(AMIGAOS4) || (defined(NOX11) && defined(NOEGL) && !defined(_WIN32))
+#endif // defined(AMIGAOS4) || (defined(NOX11) && defined(NOEGL)
 
 #include "../config.h"
 #include "../glx/hardext.h"
@@ -1239,7 +1245,7 @@ void show_fps() {
         } else if (frame1 < now) {
             if (last_frame < now) {
                 float change = current_frames / (float)(now - last_frame);
-                float weight = 0.7;
+                float weight = 0.7f;
                 if (! fps) {
                     fps = change;
                 } else {

--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -74,7 +74,7 @@ EXPORT
 #else
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define BUILD_WINDOWS_DLL
-// dll can't initialized Mali Emulator in startup code :(
+// dll can't initialize emulator in startup code :(
 static unsigned char dll_inited;
 EXPORT
 #endif
@@ -84,8 +84,8 @@ __attribute__((constructor(101)))
 #endif
 void initialize_gl4es() {
 #ifdef BUILD_WINDOWS_DLL
-    if(!dll_inited && GetModuleHandleW(L"libMaliEmulator")) {
-       LOGE("libMaliEmulator can't be initialized fron DllMain (directX limitation)\n");
+    if(!dll_inited) {
+       LOGE("Windows ES emulator's can't be initialized from DllMain (directX limitation)\n");
        return;
     }
 #endif

--- a/src/gl/loader.c
+++ b/src/gl/loader.c
@@ -32,6 +32,9 @@ void *open_lib(const char **names, const char *override) {
 #else
 #include <limits.h>
 #endif
+#else
+__declspec(dllimport)
+struct HINSTANCE__* __stdcall LoadLibraryW(const wchar_t*);
 #endif
 #include "logs.h"
 #include "init.h"

--- a/src/gl/loader.h
+++ b/src/gl/loader.h
@@ -78,6 +78,9 @@ typedef EGLSurface (*eglCreateStreamProducerSurfaceKHR_PTR)(EGLDisplay dpy, EGLC
 #elif !defined(_WIN32)
 #include <dlfcn.h>
 #else
+typedef intptr_t (*FPROC)();
+__declspec(dllimport)
+FPROC __stdcall GetProcAddress(struct HINSTANCE__*, const char*);
 #ifdef _MSC_VER
 __forceinline
 #elif defined(__GNUC__)

--- a/src/gl/queries.c
+++ b/src/gl/queries.c
@@ -4,6 +4,12 @@
 #else
 #include <sys/time.h>
 #endif
+#else
+#ifdef _MSC_VER
+#pragma warning(disable : 4028 4133)
+#endif
+__declspec(dllimport)
+void __stdcall GetSystemTimeAsFileTime(unsigned __int64*);
 #endif
 
 #include "queries.h"
@@ -64,7 +70,7 @@ void del_querie(GLuint querie) {
 unsigned long long get_clock() {
 	unsigned long long now;
 	#ifdef _WIN32
-        GetSystemTimeAsFileTime((LPFILETIME)&now);
+        GetSystemTimeAsFileTime((unsigned __int64*)&now);
 	#elif defined(USE_CLOCK)
 	struct timespec out;
 	clock_gettime(CLOCK_MONOTONIC_RAW, &out);

--- a/src/glx/hardext.c
+++ b/src/glx/hardext.c
@@ -80,9 +80,7 @@ static int testTextureCubeLod() {
     return compiled;
 }
 
-#if defined(NOX11) && defined(NOEGL)
-__attribute__((visibility("default")))
-#endif
+EXPORT
 void GetHardwareExtensions(int notest)
 {
     if(tested) return;

--- a/src/glx/hardext.h
+++ b/src/glx/hardext.h
@@ -74,6 +74,6 @@ typedef struct _hardext {
 
 EXPORT extern hardext_t hardext;
 
-void GetHardwareExtensions(int test);
+EXPORT void GetHardwareExtensions(int test);
 
 #endif


### PR DESCRIPTION
…vialize validation code on init

2. fix Windows build when NOEGL=1

-------
FYI: When processing gl4es_initialize at the start, emulators "swear" (when making requests from gl_init) about the lack of context (calls to gles_glGetInteger in glstate.c: 387,388,441,442,611,612),
Maybe the emulators are wrong, but ...
