### PR TITLE
Replace "ifndef ANDROID" with "ifndef NOX11" for X11 support in "include/GL/glx.h"

### DIFF
--- a/include/GL/glx.h
+++ b/include/GL/glx.h
@@ -35,10 +35,10 @@
 #pragma message disable nosimpint
 #endif
 #endif
-#ifndef ANDROID
+#ifndef NOX11
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#endif //ANDROID
+#endif // NOX11
 #ifdef __VMS
 # ifdef __cplusplus
 #pragma message enable nosimpint


### PR DESCRIPTION
This change follows https://github.com/ptitSeb/gl4es/blob/c3c172dc098dbd379420a3111b1142c4d7fbddd7/src/glx/utils.h#L4-L7

So it should fix build problems for targets that is:
1. Android with X11 support (maybe, some day)
2. Other non X11 platforms that isn't Android