### PR TITLE
[GLSL 150] Add a new shader converter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(NO_INIT_CONSTRUCTOR "disable automatic initialization (useful for static 
 option(USE_ANDROID_LOG "Set to ON to use Android log instead of stdio" ${USE_ANDROID_LOG})
 option(EGL_WRAPPER "Set to ON to build EGL wrapper" ${EGL_WRAPPER})
 option(GLX_STUBS "Set to ON to build GLX function stubs" ${GLX_STUBS})
+option(USE_EXPERIMENTAL_FEATURE "Set to ON to build with experimental features" ${USE_EXPERIMENTAL_FEATURE})
 
 include(CheckSymbolExists)
 check_symbol_exists(backtrace "execinfo.h" HAS_BACKTRACE)
@@ -183,6 +184,10 @@ if(USE_CCACHE)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
     endif()
+endif()
+
+if(USE_EXPERIMENTAL_FEATURE)
+    add_definitions(-DUSE_EXPERIMENTAL_FEATURE)
 endif()
 
 link_directories(${CMAKE_SOURCE_DIR}/lib)

--- a/src/gl/buffers.h
+++ b/src/gl/buffers.h
@@ -177,7 +177,9 @@ typedef struct {
     GLint           divisor;
     GLuint          real_buffer;    // If there is a real VBO binded
     const GLvoid*   real_pointer;   // the pointer related to real VBO
+#ifdef USE_EXPERIMENTAL_FEATURE
     int             integer;
+#endif
 } vertexattrib_t;
 
 typedef struct {

--- a/src/gl/fpe.c
+++ b/src/gl/fpe.c
@@ -1027,7 +1027,9 @@ void realize_glenv(int ispoint, int first, int count, GLenum type, const void* i
     LOAD_GLES2(glEnableVertexAttribArray)
     LOAD_GLES2(glDisableVertexAttribArray);
     LOAD_GLES2(glVertexAttribPointer);
+#ifdef USE_EXPERIMENTAL_FEATURE
     LOAD_GLES2(glVertexAttribIPointer);
+#endif
     LOAD_GLES2(glVertexAttrib4fv);
     LOAD_GLES2(glUseProgram);
     // update texture state for fpe only
@@ -1450,7 +1452,9 @@ void realize_glenv(int ispoint, int first, int count, GLenum type, const void* i
                         v->size = 4;
                         v->type = GL_FLOAT;
                         v->normalized = 0;
+#ifdef USE_EXPERIMENTAL_FEATURE
                         v->integer = 0;
+#endif
                         v->pointer = scratch->scratch[scratch->size++] = copy_gl_pointer_color_bgra(ptr, w->stride, 4, imin, imax);
                         v->pointer = (char*)v->pointer - imin*4*sizeof(GLfloat);   // adjust for min...
                         v->stride = 0;
@@ -1468,7 +1472,9 @@ void realize_glenv(int ispoint, int first, int count, GLenum type, const void* i
                     v->size = w->size;
                     v->type = w->type;
                     v->normalized = w->normalized;
+#ifdef USE_EXPERIMENTAL_FEATURE
                     v->integer = w->integer;
+#endif
                     v->stride = w->stride;
                     v->real_buffer = w->real_buffer;
                     v->real_pointer = w->real_pointer;
@@ -1477,12 +1483,14 @@ void realize_glenv(int ispoint, int first, int count, GLenum type, const void* i
                 }
                 DBG(printf("using Buffer %d\n", v->real_buffer);)
                 bindBuffer(GL_ARRAY_BUFFER, v->real_buffer);
-
+#ifdef USE_EXPERIMENTAL_FEATURE
                 if (v->integer) {
                     gles_glVertexAttribIPointer(i, v->size, v->type, v->stride, v->pointer);
                     DBG(printf("glVertexAttribIPointer(%d, %d, %s, %d, %p)\n", i, v->size, PrintEnum(v->type), v->stride, (GLvoid*)((uintptr_t)v->pointer+((v->buffer)?(uintptr_t)v->buffer->data:0)));)
                 }
-                else {
+                else
+#endif
+                {
                     gles_glVertexAttribPointer(i, v->size, v->type, v->normalized, v->stride, v->pointer);
                     DBG(printf("glVertexAttribPointer(%d, %d, %s, %d, %d, %p)\n", i, v->size, PrintEnum(v->type), v->normalized, v->stride, (GLvoid*)((uintptr_t)v->pointer+((v->buffer)?(uintptr_t)v->buffer->data:0)));)
                 }

--- a/src/gl/glesfuncs.inc
+++ b/src/gl/glesfuncs.inc
@@ -236,6 +236,8 @@ _EX(glVertexAttrib3fv);
 _EX(glVertexAttrib4f);
 _EX(glVertexAttrib4fv);
 _EX(glVertexAttribPointer);
+#ifdef USE_EXPERIMENTAL_FEATURE
 _EX(glVertexAttribIPointer);
+#endif
 _EX(glVertexPointer);
 _EX(glViewport);

--- a/src/gl/init.h
+++ b/src/gl/init.h
@@ -80,6 +80,9 @@ typedef struct _globals4es {
  char drmcard[50];
  #endif
  char version[50];
+ #ifdef USE_EXPERIMENTAL_FEATURE
+ int shaderconverter;
+ #endif
 } globals4es_t;
 
 extern globals4es_t globals4es;

--- a/src/gl/loader.c
+++ b/src/gl/loader.c
@@ -41,6 +41,9 @@ struct HINSTANCE__* __stdcall LoadLibraryW(const wchar_t*);
 #include "envvars.h"
 
 void *gles = NULL, *egl = NULL, *bcm_host = NULL, *vcos = NULL, *gbm = NULL, *drm = NULL;
+#ifdef USE_EXPERIMENTAL_FEATURE
+void *glslconv = NULL;
+#endif
 #ifndef _WIN32
 #ifndef NO_GBM
 static const char *drm_lib[] = {

--- a/src/gl/loader.h
+++ b/src/gl/loader.h
@@ -102,7 +102,11 @@ extern void (APIENTRY_GL4ES *gl4es_getMainFBSize)(GLint* width, GLint* height);
 NonAliasExportDecl(void*,proc_address,(void *lib, const char *name));
 // will become references to dlopen'd gles and egl
 extern void *gles, *bcm_host, *vcos, *gbm, *drm;
+#ifdef USE_EXPERIMENTAL_FEATURE
+extern void *glslconv;
+#endif
 EXPORT extern void *egl;
+void *open_lib(const char **names, const char *override);
 #if defined __APPLE__ || defined __EMSCRIPTEN__
 #define NO_LOADER
 #endif

--- a/src/gl/vertexattrib.c
+++ b/src/gl/vertexattrib.c
@@ -32,7 +32,9 @@ void APIENTRY_GL4ES gl4es_glVertexAttribPointer(GLuint index, GLint size, GLenum
     v->size = size;
     v->type = type;
     v->normalized = normalized;
+#ifdef USE_EXPERIMENTAL_FEATURE
     v->integer = 0;
+#endif
     v->stride = stride;
     v->pointer = pointer;
     v->buffer = glstate->vao->vertex;
@@ -44,6 +46,7 @@ void APIENTRY_GL4ES gl4es_glVertexAttribPointer(GLuint index, GLint size, GLenum
         v->real_pointer = 0;
     }
 }
+#ifdef USE_EXPERIMENTAL_FEATURE
 void APIENTRY_GL4ES gl4es_glVertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid * pointer) {
     DBG(printf("glVertexAttribIPointer(%d, %d, %s, %d, %p), vertex buffer = %p\n", index, size, PrintEnum(type), stride, pointer, (glstate->vao->vertex)?glstate->vao->vertex->data:0);)
     FLUSH_BEGINEND;
@@ -75,6 +78,7 @@ void APIENTRY_GL4ES gl4es_glVertexAttribIPointer(GLuint index, GLint size, GLenu
         v->real_pointer = 0;
     }
 }
+#endif // USE_EXPERIMENTAL_FEATURE
 void APIENTRY_GL4ES gl4es_glEnableVertexAttribArray(GLuint index) {
     DBG(printf("glEnableVertexAttrib(%d)\n", index);)
     FLUSH_BEGINEND;
@@ -193,7 +197,9 @@ void APIENTRY_GL4ES gl4es_glVertexAttribDivisor(GLuint index, GLuint divisor) {
 }
 
 AliasExport(void,glVertexAttribPointer,,(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid * pointer));
+#ifdef USE_EXPERIMENTAL_FEATURE
 AliasExport(void,glVertexAttribIPointer,,(GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid * pointer));
+#endif
 AliasExport(void,glEnableVertexAttribArray,,(GLuint index));
 AliasExport(void,glDisableVertexAttribArray,,(GLuint index));
 AliasExport(void,glVertexAttrib4f,,(GLuint index, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3));

--- a/src/gl/vertexattrib.h
+++ b/src/gl/vertexattrib.h
@@ -6,7 +6,9 @@
 // actual definition of vertexattrib_t is in buffer.h, as they are part of VAO...
 
 void APIENTRY_GL4ES gl4es_glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid * pointer);
+#ifdef USE_EXPERIMENTAL_FEATURE
 void APIENTRY_GL4ES gl4es_glVertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid * pointer);
+#endif
 void APIENTRY_GL4ES gl4es_glEnableVertexAttribArray(GLuint index);
 void APIENTRY_GL4ES gl4es_glDisableVertexAttribArray(GLuint index);
 

--- a/src/gl/wrap/gles.c
+++ b/src/gl/wrap/gles.c
@@ -2392,6 +2392,7 @@ void APIENTRY_GL4ES gl4es_glVertexAttribPointer(GLuint index, GLint size, GLenum
 }
 AliasExport(void,glVertexAttribPointer,,(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid * pointer));
 #endif
+#ifdef USE_EXPERIMENTAL_FEATURE
 #ifndef skip_glVertexAttribIPointer
 void APIENTRY_GL4ES gl4es_glVertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid * pointer) {
     LOAD_GLES(glVertexAttribIPointer);
@@ -2402,6 +2403,7 @@ void APIENTRY_GL4ES gl4es_glVertexAttribIPointer(GLuint index, GLint size, GLenu
 }
 AliasExport(void,glVertexAttribIPointer,,(GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid * pointer));
 #endif
+#endif // USE_EXPERIMENTAL_FEATURE
 #ifndef skip_glVertexPointer
 void APIENTRY_GL4ES gl4es_glVertexPointer(GLint size, GLenum type, GLsizei stride, const GLvoid * pointer) {
     LOAD_GLES(glVertexPointer);

--- a/src/gl/wrap/gles.h
+++ b/src/gl/wrap/gles.h
@@ -3661,6 +3661,7 @@ packed_call_t* APIENTRY_GL4ES glCopyPackedCall(const packed_call_t *packed);
 #define glViewport_INDEXED INDEXED_void_GLint_GLint_GLsizei_GLsizei
 #define glViewport_FORMAT FORMAT_void_GLint_GLint_GLsizei_GLsizei
 
+#ifdef USE_EXPERIMENTAL_FEATURE
 #define glVertexAttribIPointer_INDEX 242
 #define glVertexAttribIPointer_RETURN void
 #define glVertexAttribIPointer_ARG_NAMES index, size, type, stride, pointer
@@ -3668,6 +3669,7 @@ packed_call_t* APIENTRY_GL4ES glCopyPackedCall(const packed_call_t *packed);
 #define glVertexAttribIPointer_PACKED PACKED_void_GLuint_GLint_GLenum_GLsizei_const_GLvoid___GENPT__
 #define glVertexAttribIPointer_INDEXED INDEXED_void_GLuint_GLint_GLenum_GLsizei_const_GLvoid___GENPT__
 #define glVertexAttribIPointer_FORMAT FORMAT_void_GLuint_GLint_GLenum_GLsizei_const_GLvoid___GENPT__
+#endif
 
 void APIENTRY_GL4ES gl4es_glActiveTexture(glActiveTexture_ARG_EXPAND);
 typedef void (APIENTRY_GLES * glActiveTexture_PTR)(glActiveTexture_ARG_EXPAND);
@@ -4152,9 +4154,10 @@ typedef void (APIENTRY_GLES * glVertexPointer_PTR)(glVertexPointer_ARG_EXPAND);
 void APIENTRY_GL4ES gl4es_glViewport(glViewport_ARG_EXPAND);
 typedef void (APIENTRY_GLES * glViewport_PTR)(glViewport_ARG_EXPAND);
 
+#ifdef USE_EXPERIMENTAL_FEATURE
 void APIENTRY_GL4ES gl4es_glVertexAttribIPointer(glVertexAttribIPointer_ARG_EXPAND);
 typedef void (APIENTRY_GLES * glVertexAttribIPointer_PTR)(glVertexAttribIPointer_ARG_EXPAND);
-
+#endif
 
 
 #ifndef direct_glActiveTexture
@@ -6725,6 +6728,7 @@ typedef void (APIENTRY_GLES * glVertexAttribIPointer_PTR)(glVertexAttribIPointer
     glPushCall((void *)packed_data); \
 }
 #endif
+#ifdef USE_EXPERIMENTAL_FEATURE
 #ifndef direct_glVertexAttribIPointer
 #define push_glVertexAttribIPointer(index, size, type, stride, pointer) { \
     glVertexAttribIPointer_PACKED *packed_data = malloc(sizeof(glVertexAttribIPointer_PACKED)); \
@@ -6738,6 +6742,7 @@ typedef void (APIENTRY_GLES * glVertexAttribIPointer_PTR)(glVertexAttribIPointer
     glPushCall((void *)packed_data); \
 }
 #endif
+#endif // USE_EXPERIMENTAL_FEATURE
 #ifndef direct_glVertexPointer
 #define push_glVertexPointer(size, type, stride, pointer) { \
     glVertexPointer_PACKED *packed_data = malloc(sizeof(glVertexPointer_PACKED)); \

--- a/src/gl/wrap/skips.h
+++ b/src/gl/wrap/skips.h
@@ -204,7 +204,9 @@
 
 // vertexattrib.c
 #define skip_glVertexAttribPointer
+#ifdef USE_EXPERIMENTAL_FEATURE
 #define skip_glVertexAttribIPointer
+#endif
 #define skip_glEnableVertexAttribArray
 #define skip_glDisableVertexAttribArray
 #define skip_glVertexAttrib1f


### PR DESCRIPTION
The experimental shader converter is based on [glslang](https://github.com/AOF-Dev/glslang-converter). It can convert some GLSL 150 shader to GLSL ES 300. I have tested it on both `desktop X11` and `Android` with Minecraft JE 1.18.1, and the result is good.