### PR TITLE
Unbind framebuffer, if it is bound, before freeing it

### DIFF
--- a/src/gl/framebuffers.c
+++ b/src/gl/framebuffers.c
@@ -153,6 +153,15 @@ void APIENTRY_GL4ES gl4es_glDeleteFramebuffers(GLsizei n, GLuint *framebuffers) 
                                 tex->renderstencil = 0;
                             }
                         }
+                        if (glstate->fbo.current_fb == fb) {
+                            glstate->fbo.current_fb = 0;
+                        }
+                        if (glstate->fbo.fbo_read == fb) {
+                            glstate->fbo.fbo_read = 0;
+                        }
+                        if (glstate->fbo.fbo_draw == fb) {
+                            glstate->fbo.fbo_draw = 0;
+                        }
                         free(fb);
                         kh_del(framebufferlist_t, glstate->fbo.framebufferlist, k);                        
                     }


### PR DESCRIPTION
I got an error with Valgrind because the deleted framebuffer was still bound.