### PR TITLE
Don't upgrade depth to GL_UNSIGNED_INT when GL_UNSIGNED_SHORT is given

### DIFF
--- a/src/gl/texture.c
+++ b/src/gl/texture.c
@@ -159,7 +159,9 @@ void internal2format_type(GLenum internalformat, GLenum *format, GLenum *type)
             break;
         case GL_DEPTH_COMPONENT:
             *format = GL_DEPTH_COMPONENT;
-            *type = (hardext.depth24)?GL_UNSIGNED_INT:GL_UNSIGNED_SHORT;
+            if (*type != GL_UNSIGNED_SHORT) {
+                *type = (hardext.depth24)?GL_UNSIGNED_INT:GL_UNSIGNED_SHORT;
+            }
             break;
         case GL_DEPTH_STENCIL:
         case GL_DEPTH24_STENCIL8:


### PR DESCRIPTION
This is a tentative fix for #374.

When the depth data provided by the application a GL_UNSIGNED_INT is expected if depth24 is supported although GL_UNSIGNED_SHORT is provided.
In addition, no conversion is supported for depth buffers.