### PR TITLE
arbparser: add brackets to case blocks where variables are declared, to prevent warnings spam on GCC

### DIFF
--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -121,7 +121,7 @@ eToken readNextToken(sCurStatus* curStatus) {
 		
 		break;
 		
-	case '.':
+	case '.': {
 		curStatus->endOfToken = curStatus->codePtr + 1;
 		
 		// Plain '.' is TOK_POINT, '..' is TOK_UPTO
@@ -167,8 +167,8 @@ eToken readNextToken(sCurStatus* curStatus) {
 			while (e-- != 0) curStatus->tokFloat *= s ? 10.f : 0.1f;
 		}
 		
-		break;
-		
+		break; }
+
 	case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G':
 	case 'H': case 'I': case 'J': case 'K': case 'L': case 'M': case 'N':
 	case 'O': case 'P': case 'Q': case 'R': case 'S': case 'T': case 'U':
@@ -2467,7 +2467,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				FAIL("Invalid token");
 			}
 			break;
-			
+
 		case VARTYPE_ATTRIB:
 		case VARTYPE_OUTPUT:
 		case VARTYPE_PARAM:
@@ -2671,7 +2671,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				FAIL("Invalid token");
 			}
 			break;
-			
+
 		case VARTYPE_OUTPUT:
 			switch (curStatusPtr->curToken) {
 			case TOK_IDENTIFIER: {
@@ -2854,7 +2854,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				curStatusPtr->curValue.newVar.state = 12;
 				break;
 				
-			case TOK_END_OF_INST:
+			case TOK_END_OF_INST: {
 				if ((curStatusPtr->curValue.newVar.state != 1) && (curStatusPtr->curValue.newVar.state != 12)) {
 					FAIL("Invalid state");
 				}
@@ -2897,8 +2897,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				curStatusPtr->valueType = TYPE_NONE;
 				curStatusPtr->status = ST_LINE_START;
 				
-				break;
-				
+				break; }
+
 			case TOK_WHITESPACE:
 			case TOK_NEWLINE:
 				break;
@@ -3031,7 +3031,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				}
 				break;
 				
-			case TOK_END_OF_INST:
+			case TOK_END_OF_INST: {
 				if (curStatusPtr->curValue.newVar.state != 15) {
 					FAIL("Invalid state");
 				}
@@ -3090,8 +3090,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				curStatusPtr->valueType = TYPE_NONE;
 				curStatusPtr->status = ST_LINE_START;
 				
-				break;
-				
+				break; }
+
 			case TOK_WHITESPACE:
 			case TOK_NEWLINE:
 				break;
@@ -3100,7 +3100,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				FAIL("Invalid token");
 			}
 			break;
-			
+
 		case VARTYPE_ADDRESS:
 		case VARTYPE_TEMP:
 		case VARTYPE_ALIAS:
@@ -3112,7 +3112,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 			FAIL("Unknown error (unintended fallthrough?)");
 		}
 		break;
-		
+
 	case ST_ALIAS:
 		switch (curStatusPtr->curToken) {
 		case TOK_IDENTIFIER: {
@@ -3145,7 +3145,7 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 		break;
 	case ST_ALIASING:
 		switch (curStatusPtr->curToken) {
-		case TOK_IDENTIFIER:
+		case TOK_IDENTIFIER: {
 			if (curStatusPtr->valueType != TYPE_ALIAS_DECL) {
 				// Already aliased
 				FAIL("Too many identifiers");
@@ -3170,8 +3170,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 			kh_val(curStatusPtr->varsMap, varIdx) = var;
 			
 			curStatusPtr->valueType = TYPE_NONE;
-			break;
-			
+			break; }
+
 		case TOK_WHITESPACE:
 		case TOK_NEWLINE:
 			break;

--- a/src/gl/arbparser.c
+++ b/src/gl/arbparser.c
@@ -166,8 +166,8 @@ eToken readNextToken(sCurStatus* curStatus) {
 			
 			while (e-- != 0) curStatus->tokFloat *= s ? 10.f : 0.1f;
 		}
-		
-		break; }
+		}
+		break;
 
 	case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G':
 	case 'H': case 'I': case 'J': case 'K': case 'L': case 'M': case 'N':
@@ -2356,7 +2356,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				FAIL("Unknown operand");
 			}
 			free(tok);
-			break; }
+			}
+			break;
 			
 		case TOK_LINE_COMMENT:
 			curStatusPtr->status = ST_LINE_COMMENT;
@@ -2415,7 +2416,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				
 				pushArray((sArray*)curStatusPtr->curValue.newVar.var, tok);
 				curStatusPtr->curValue.newVar.state = 1;
-				break; }
+				}
+				break;
 				
 			case TOK_COMMA: {
 				if (curStatusPtr->curValue.newVar.state != 1) {
@@ -2436,7 +2438,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				pushArray((sArray*)&curStatusPtr->variables, curStatusPtr->curValue.newVar.var);
 				curStatusPtr->curValue.newVar.var = createVariable(curStatusPtr->curValue.newVar.var->type);
 				curStatusPtr->curValue.newVar.state = 0;
-				break; }
+				}
+				break;
 				
 			case TOK_END_OF_INST: {
 				if (curStatusPtr->curValue.newVar.state != 1) {
@@ -2457,7 +2460,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				pushArray((sArray*)&curStatusPtr->variables, curStatusPtr->curValue.newVar.var);
 				curStatusPtr->valueType = TYPE_NONE;
 				curStatusPtr->status = ST_LINE_START;
-				break; }
+				}
+				break;
 				
 			case TOK_WHITESPACE:
 			case TOK_NEWLINE:
@@ -2500,7 +2504,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				
 				pushArray((sArray*)curStatusPtr->curValue.newVar.var, tok);
 				curStatusPtr->curValue.newVar.state = 1;
-				break; }
+				}
+				break;
 				
 			case TOK_EQUALS:
 				if (curStatusPtr->curValue.newVar.state != 1) {
@@ -2601,8 +2606,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				pushArray((sArray*)&curStatusPtr->curValue.newVar, getToken(curStatusPtr));
 				
 				curStatusPtr->curValue.newVar.state = 1;
-				
-				break; }
+				}
+				break;
 				
 			case TOK_POINT:
 				if (curStatusPtr->curValue.newVar.state == 0) {
@@ -2660,8 +2665,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				freeArray((sArray*)&curStatusPtr->curValue.newVar);
 				curStatusPtr->valueType = TYPE_NONE;
 				curStatusPtr->status = ST_LINE_START;
-				
-				break; }
+				}
+				break;
 				
 			case TOK_WHITESPACE:
 			case TOK_NEWLINE:
@@ -2682,8 +2687,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				pushArray((sArray*)&curStatusPtr->curValue.newVar, getToken(curStatusPtr));
 				
 				curStatusPtr->curValue.newVar.state = 1;
-				
-				break; }
+				}
+				break;
 				
 			case TOK_POINT:
 				if (curStatusPtr->curValue.newVar.state == 0) {
@@ -2723,8 +2728,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				freeArray((sArray*)&curStatusPtr->curValue.newVar);
 				curStatusPtr->valueType = TYPE_NONE;
 				curStatusPtr->status = ST_LINE_START;
-				
-				break; }
+				}
+				break;
 				
 			case TOK_WHITESPACE:
 			case TOK_NEWLINE:
@@ -2896,8 +2901,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				freeArray((sArray*)&curStatusPtr->curValue.newVar);
 				curStatusPtr->valueType = TYPE_NONE;
 				curStatusPtr->status = ST_LINE_START;
-				
-				break; }
+				}
+				break;
 
 			case TOK_WHITESPACE:
 			case TOK_NEWLINE:
@@ -3089,8 +3094,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				freeArray((sArray*)&curStatusPtr->curValue.newVar);
 				curStatusPtr->valueType = TYPE_NONE;
 				curStatusPtr->status = ST_LINE_START;
-				
-				break; }
+				}
+				break;
 
 			case TOK_WHITESPACE:
 			case TOK_NEWLINE:
@@ -3128,8 +3133,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				FAIL("Cannot redeclare variable");
 			}
 			curStatusPtr->curValue.string = tok;
-			
-			break; }
+			}
+			break;
 			
 		case TOK_WHITESPACE:
 		case TOK_NEWLINE:
@@ -3170,7 +3175,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 			kh_val(curStatusPtr->varsMap, varIdx) = var;
 			
 			curStatusPtr->valueType = TYPE_NONE;
-			break; }
+			}
+			break;
 
 		case TOK_WHITESPACE:
 		case TOK_NEWLINE:
@@ -3240,8 +3246,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				}
 				copyToken(curStatusPtr, faa + strlen(faa));
 				curVarPtr->floatArrAddr = faa;
+				}
 				break;
-			}
 				
 			default:
 				break;
@@ -3266,8 +3272,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				copyToken(curStatusPtr, faa + strlen(faa));
 				curVarPtr->floatArrAddr = faa;
 				++curStatusPtr->curValue.newInst.state;
+				}
 				break;
-			}
 				
 			default:
 				FAIL("Invalid state");
@@ -3312,8 +3318,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				copyToken(curStatusPtr, faa + strlen(faa));
 				curVarPtr->floatArrAddr = faa;
 				curStatusPtr->curValue.newInst.state = STATE_AFTER_VALID_LSQBR_END;
+				}
 				break;
-			}
 				
 			case STATE_LBRACE:
 			case STATE_LBRACE_COM1:
@@ -3334,8 +3340,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 			case STATE_AFTER_SIGN: {
 				pushArray((sArray*)&curStatusPtr->_fixedNewVar, getToken(curStatusPtr));
 				curStatusPtr->curValue.newInst.state = STATE_AFTER_NUMBER;
+				}
 				break;
-			}
 				
 			case STATE_LBRACE:
 			case STATE_LBRACE_COM1:
@@ -3380,8 +3386,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 					pushArray((sArray*)&curStatusPtr->_fixedNewVar, strdup(tok));
 					curStatusPtr->curValue.newInst.state = STATE_AFTER_ELEMENT;
 				}
+				}
 				break;
-			}
 				
 			case STATE_AFTER_DOT:
 				pushArray((sArray*)&curStatusPtr->_fixedNewVar, strdup(tok));
@@ -3417,8 +3423,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				}
 				
 				curStatusPtr->curValue.newInst.state = STATE_AFTER_SWIZZLE;
-				
-				break; }
+				}
+				break;
 				
 			case STATE_AFTER_VALID_LSQBR_START: {
 				khint_t idx = kh_get(variables, curStatusPtr->varsMap, tok);
@@ -3434,8 +3440,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				
 				curVarPtr->floatArrAddr = getToken(curStatusPtr);
 				++curStatusPtr->curValue.newInst.state;
+				}
 				break;
-			}
 				
 			case STATE_AFTER_VALID_LSQBR_ADOT: {
 				if ((getTokenLength(curStatusPtr) != 1) || (tok[0] != 'x')) {
@@ -3511,8 +3517,8 @@ void parseToken(sCurStatus* curStatusPtr, int vertex, char **error_msg, struct s
 				curVarPtr->floatArrAddr = faa;
 				
 				++curStatusPtr->curValue.newInst.state;
+				}
 				break;
-			}
 				
 			case STATE_AFTER_ELEMENT:
 				curStatusPtr->curValue.newInst.state = STATE_AFTER_DOT;


### PR DESCRIPTION
GCC 11.2 is a bit paranoid about these declarations and goes into some recursive warning loop and never explains what was wrong on that line. I added some brackets, and it helped to avoid the flood

```
[ 60/415] Compiling ref_gl/gl4es/src/gl/arbparser.c
../ref_gl/gl4es/src/gl/arbparser.c: In function ‘readNextToken’:
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
      |                       ^~~
../ref_gl/gl4es/src/gl/arbparser.c:36:9: note: switch starts here
   36 |         switch (*curStatus->codePtr) {
      |         ^~~~~~
../ref_gl/gl4es/src/gl/arbparser.c:137:23: note: ‘exp’ declared here
  137 |                 float exp = 0.1f;
```