### PR TITLE
Add necessary OGU EGL wrapper functions.

### DIFF
--- a/src/egl/egl.c
+++ b/src/egl/egl.c
@@ -199,6 +199,28 @@ EGLBoolean gl4es_eglCopyBuffers(EGLDisplay dpy, EGLSurface surface, EGLNativePix
     return egl_eglCopyBuffers(dpy, surface, target);
 }
 
+EGLSyncKHR gl4es_eglCreateSyncKHR(EGLDisplay dpy, EGLenum type, const EGLint *attrib_list) {
+    LOAD_EGL(eglCreateSyncKHR);
+    return egl_eglCreateSyncKHR(dpy, type, attrib_list);
+}
+
+EGLint gl4es_eglClientWaitSyncKHR(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout) {
+    LOAD_EGL(eglClientWaitSyncKHR);
+    return egl_eglClientWaitSyncKHR(dpy, sync, flags, timeout);
+}
+
+NativePixmapType gl4es_egl_create_pixmap_ID_mapping(void *pixmap)
+{
+    LOAD_EGL(egl_create_pixmap_ID_mapping);
+    return egl_egl_create_pixmap_ID_mapping(pixmap);
+}
+
+NativePixmapType gl4es_egl_destroy_pixmap_ID_mapping(int id)
+{
+    LOAD_EGL(egl_destroy_pixmap_ID_mapping);
+    return egl_egl_destroy_pixmap_ID_mapping(id);
+}
+
 AliasExport(EGLint, eglGetError,,(void));
 AliasExport(EGLDisplay, eglGetDisplay,,(EGLNativeDisplayType display_id));
 AliasExport(EGLBoolean, eglInitialize,,(EGLDisplay dpy, EGLint *major, EGLint *minor));
@@ -234,4 +256,8 @@ AliasExport(EGLBoolean, eglWaitGL,,(void));
 AliasExport(EGLBoolean, eglWaitNative,,(EGLint engine));
 AliasExport(EGLBoolean, eglSwapBuffers,,(EGLDisplay dpy, EGLSurface surface));
 AliasExport(EGLBoolean, eglCopyBuffers,,(EGLDisplay dpy, EGLSurface surface, EGLNativePixmapType target));
+AliasExport(EGLSyncKHR, eglCreateSyncKHR,,(EGLDisplay dpy, EGLenum type, const EGLint *attrib_list));
+AliasExport(EGLint, eglClientWaitSyncKHR,,(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout));
 
+AliasExport(NativePixmapType, egl_create_pixmap_ID_mapping,,(void *pixmap));
+AliasExport(NativePixmapType, egl_destroy_pixmap_ID_mapping,,(int id));

--- a/src/egl/egl.h
+++ b/src/egl/egl.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -46,6 +47,13 @@ EGLBoolean gl4es_eglWaitNative(EGLint engine);
 EGLBoolean gl4es_eglSwapBuffers(EGLDisplay dpy, EGLSurface surface);
 EGLBoolean gl4es_eglCopyBuffers(EGLDisplay dpy, EGLSurface surface, EGLNativePixmapType target);
 void* gl4es_eglGetProcAddress(const char *name);
+
+EGLSyncKHR gl4es_eglCreateSyncKHR(EGLDisplay dpy, EGLenum type, const EGLint *attrib_list);
+EGLint gl4es_eglClientWaitSyncKHR(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout);
+
+// Undocumented libmali internals, needed for ODROID Go Ultra
+NativePixmapType gl4es_egl_create_pixmap_ID_mapping(void *pixmap);
+NativePixmapType gl4es_egl_destroy_pixmap_ID_mapping(int id);
 
 #endif // _EGL_EGL_H
 

--- a/src/egl/lookup.c
+++ b/src/egl/lookup.c
@@ -54,6 +54,11 @@ void* gl4es_eglGetProcAddress(const char *name) {
     _EX(eglWaitNative);
     _EX(eglSwapBuffers);
     _EX(eglCopyBuffers);
+    _EX(eglCreateSyncKHR);
+    _EX(eglClientWaitSyncKHR);
+
+    _EX(egl_create_pixmap_ID_mapping);
+    _EX(egl_destroy_pixmap_ID_mapping);
     
     _EX(glXGetProcAddress);
     _ARB(glXGetProcAddress);

--- a/src/gl/loader.h
+++ b/src/gl/loader.h
@@ -49,6 +49,11 @@ typedef EGLBoolean (*eglUnlockSurfaceKHR_PTR)(EGLDisplay display, EGLSurface sur
 typedef EGLBoolean (*eglWaitClient_PTR)();
 typedef EGLBoolean (*eglWaitGL_PTR)();
 typedef EGLBoolean (*eglWaitNative_PTR)(EGLint engine);
+typedef EGLSyncKHR (*eglCreateSyncKHR_PTR)(EGLDisplay dpy, EGLenum type, const EGLint * attrib_list);
+typedef EGLint (*eglClientWaitSyncKHR_PTR)(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout);
+
+typedef NativePixmapType (*egl_create_pixmap_ID_mapping_PTR)(void *pixmap);
+typedef NativePixmapType (*egl_destroy_pixmap_ID_mapping_PTR)(int id);
 #ifdef TEXSTREAM
 typedef EGLSurface (*eglCreatePixmapSurfaceHI_PTR)(EGLDisplay dpy, EGLConfig config, struct EGLClientPixmapHI * pixmap);
 typedef EGLBoolean (*eglDestroyImageKHR_PTR)(EGLDisplay dpy, EGLImageKHR image);
@@ -56,7 +61,6 @@ typedef EGLBoolean (*eglDestroyStreamKHR_PTR)(EGLDisplay dpy, EGLStreamKHR strea
 typedef EGLImageKHR (*eglCreateImageKHR_PTR)(EGLDisplay dpy, EGLContext ctx, EGLenum target, EGLClientBuffer buffer, const EGLint * attrib_list);
 typedef EGLStreamKHR (*eglCreateStreamFromFileDescriptorKHR_PTR)(EGLDisplay dpy, EGLNativeFileDescriptorKHR file_descriptor);
 typedef EGLStreamKHR (*eglCreateStreamKHR_PTR)(EGLDisplay dpy, const EGLint * attrib_list);
-typedef EGLSyncKHR (*eglCreateSyncKHR_PTR)(EGLDisplay dpy, EGLenum type, const EGLint * attrib_list);
 typedef EGLBoolean (*eglDestroySyncKHR_PTR)(EGLDisplay dpy, EGLSyncKHR sync);
 typedef EGLBoolean (*eglSignalSyncKHR_PTR)(EGLDisplay dpy, EGLSyncKHR sync, EGLenum mode);
 typedef EGLBoolean (*eglGetSyncAttribKHR_PTR)(EGLDisplay dpy, EGLSyncKHR sync, EGLint attribute, EGLint * value);


### PR DESCRIPTION
SDL2 on the ODROID Go Ultra requires fences and a few reverse engineered libmali internals in order to initialize an EGLSurface using ION-backed framebuffers.

These are used in order to achieve fast, zero-copy frame presentation using the GE2D hardware blitter.