### PR TITLE
Fix glGenBuffers usage in gl4es_scratch_*

### DIFF
--- a/src/gl/gl4es.c
+++ b/src/gl/gl4es.c
@@ -1172,7 +1172,7 @@ void gl4es_scratch_vertex(int alloc) {
     LOAD_GLES(glBufferData);
     LOAD_GLES(glGenBuffers);
     if(!glstate->scratch_vertex) {
-        glGenBuffers(1, &glstate->scratch_vertex);
+        gles_glGenBuffers(1, &glstate->scratch_vertex);
     }
     if(glstate->scratch_vertex_size < alloc) {
 #ifdef AMIGAOS4
@@ -1196,7 +1196,7 @@ void gl4es_scratch_indices(int alloc) {
     LOAD_GLES(glBufferData);
     LOAD_GLES(glGenBuffers);
     if(!glstate->scratch_indices) {
-        glGenBuffers(1, &glstate->scratch_indices);
+        gles_glGenBuffers(1, &glstate->scratch_indices);
     }
     bindBuffer(GL_ELEMENT_ARRAY_BUFFER, glstate->scratch_indices);
     if(glstate->scratch_indices_size < alloc) {


### PR DESCRIPTION
I noticed that `gl4es_glGenBuffers` is mistakenly used instead of `gles_glGenBuffers`. The generated buffer is later used by gles(real) functions. This fix changes it to use the real `glGenBuffers`, like how the commented out code indicated:
https://github.com/ptitSeb/gl4es/blob/c156cc6bdccb7365ee335509dda1d306150eba91/src/gl/gl4es.c#L710-L712
