### PR TITLE
Fix bad index in fpe_VertexShader

### DIFF
--- a/src/gl/fpe_shader.c
+++ b/src/gl/fpe_shader.c
@@ -612,9 +612,9 @@ const char* const* fpe_VertexShader(shaderconv_need_t* need, fpe_state_t *state)
         tg[0] = state->texgen[i].texgen_s;
         tg[1] = state->texgen[i].texgen_t;
         tg[2] = state->texgen[i].texgen_r;
-        tg[3] = state->texgen[i].texgen_q;
-        int ntc = texnsize[t-1];
+        tg[3] = state->texgen[i].texgen_q;        
         if(t) {
+            int ntc = texnsize[t-1];
             if(comments) {
                 sprintf(buff, "// texture %d active: %X %s %s\n", i, t, mat?"with matrix":"", adjust?"npot adjusted":"");
                 ShadAppend(buff);


### PR DESCRIPTION
When t == 0. would cause a bad memory index