### PR TITLE
Fix Config[1] out of bounds in gl4es_glXCreatePbuffer

### DIFF
--- a/src/glx/glx.c
+++ b/src/glx/glx.c
@@ -2511,7 +2511,7 @@ GLXPbuffer gl4es_glXCreatePbuffer(Display * dpy, GLXFBConfig config, const int *
     egl_eglQuerySurface(eglDisplay,Surface,EGL_WIDTH,&Width);
     egl_eglQuerySurface(eglDisplay,Surface,EGL_HEIGHT,&Height);
 
-    return addPBuffer(Surface, Width, Height, Context, Config[1]);
+    return addPBuffer(Surface, Width, Height, Context, Config[0]);
 }
 
 GLXPbuffer addPixBuffer(Display *dpy, EGLSurface surface, EGLConfig Config, int Width, int Height, EGLContext Context, Pixmap pixmap, int depth, int emulated)


### PR DESCRIPTION
Shoutout to the compiler for finding it:
```
gl4es/src/glx/glx.c:2514:56: warning: array index 1 is past the end of the array (which contains 1 element) [-Warray-bounds]
    return addPBuffer(Surface, Width, Height, Context, Config[1]);
                                                       ^      ~
gl4es/src/glx/glx.c:2470:5: note: array 'Config' declared here
    EGLConfig Config[1];
    ^
```