### PR TITLE
Fix[shaderconv]: Small memory leak

### DIFF
--- a/src/gl/shaderconv.c
+++ b/src/gl/shaderconv.c
@@ -1257,6 +1257,8 @@ char* ConvertShader(const char* pEntry, int isVertex, shaderconv_need_t *need)
     printf("New Shader source:\n%s\n", Tmp);
   }
   // clean preproc'd source
+  if(versionString != NULL)
+    free(versionString);
   if(pEntry!=pBuffer)
     free(pBuffer);
   return Tmp;


### PR DESCRIPTION
Hi Seb, I realized that one string allocation was never freed after a shader has been converted.
This PR fixes a 51 bytes memory leak that could happen when converting a shader. 