### PR TITLE
Fix[framebuffer, fpe]: code typos

### DIFF
--- a/src/gl/fpe.h
+++ b/src/gl/fpe.h
@@ -236,7 +236,7 @@ typedef struct scratch_s {
 void free_scratch(scratch_t* scratch);
 
 
-fpe_fpe_t *fpe_GetCache();
+fpe_fpe_t *fpe_GetCache(fpe_cache_t *cur, fpe_state_t *state, int fixed);
 void fpe_disposeCache(fpe_cache_t* cache, int freeprog);
 
 // fpe is gles export replacement, so should use same caling conversion

--- a/src/gl/framebuffers.c
+++ b/src/gl/framebuffers.c
@@ -1441,12 +1441,12 @@ void APIENTRY_GL4ES gl4es_glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX
             if(!created) {
                 if((tex->actual.min_filter!=filter) || (tex->actual.mag_filter!=filter)) {
                     gltexture_t *old = glstate->texture.bound[ENABLED_TEX2D][0];
-                    if(old->texture != glname);
+                    if(old->texture != glname)
                         gl4es_glBindTexture(GL_TEXTURE_2D, glname);
                     gl4es_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
                     gl4es_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
                     tex->actual.min_filter = tex->actual.mag_filter = filter;
-                    if(old->texture != glname);
+                    if(old->texture != glname)
                         gl4es_glBindTexture(GL_TEXTURE_2D, old->texture);
                 }
             }


### PR DESCRIPTION
Hello once again !
I've recently migrated my build system to ndk 26-rc1 and uncovered two issues thanks to the updated compiler.