### PR TITLE
Hacks to run KiCAD accelerated mode (w/o AA)

### DIFF
--- a/src/gl/fpe.c
+++ b/src/gl/fpe.c
@@ -815,6 +815,10 @@ void APIENTRY_GL4ES fpe_glDrawElements(GLenum mode, GLsizei count, GLenum type, 
         indices = (GLvoid*)((uintptr_t)indices - (uintptr_t)(glstate->vao->elements->data));
         DBG(printf("Using VBO %d for indices\n", glstate->vao->elements->real_buffer);)
     }
+    if (!glstate->vao->elements) {
+        bindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+        DBG(printf("Unloading EBO\n"));
+    }
     realize_bufferIndex();
     gles_glDrawElements(mode, count, type, indices);
     if(use_vbo)

--- a/src/gl/shader_hacks.c
+++ b/src/gl/shader_hacks.c
@@ -383,6 +383,11 @@ static const hack_t gl4es_hacks[] = {
 "\tFogOffsetU = 0.5 / FogTexSize;\r\n"
 "\tFogScaleU  = ( FogTexSize - 1.0 ) / FogTexSize;\r\n"
 }},
+// for KiCAD
+{"        float derivative   = length( dFdx( tex ) ) * u_fontTextureWidth / 4;\n",
+1, {"        float derivative   = length( dFdx( tex ) ) * float(u_fontTextureWidth) / 4.0;\n"}},
+{"        delta = vec4( 0, 2 * pixelR, 0, 0 );\n",
+1, {"        delta = vec4( 0, 2.0 * pixelR, 0, 0 );\n"}},
 // for Iconoclasts
 // Disable hotspot shaders 1
 #ifdef GOA_CLONE


### PR DESCRIPTION
The SMAA code is quite GLES-unfriendly (using multiple color attachments).

The first commit fixes a bug that leads to misrender when opening KiCAD's own video demo PCB file, and the second bug tries to patch some shaders that will fail to compile due to the current lame shader converter.