### PR TITLE
Fix Emscripten "undefined symbol: glCallList"

### DIFF
--- a/src/gl/gl4es.c
+++ b/src/gl/gl4es.c
@@ -890,7 +890,7 @@ void APIENTRY_GL4ES glPushCall(void *call) {
 
 void APIENTRY_GL4ES gl4es_glCallLists(GLsizei n, GLenum type, const GLvoid *lists) {
     #define call(name, type) \
-        case name: glCallList(((type *)lists)[i] + glstate->list.base); break
+        case name: gl4es_glCallList(((type *)lists)[i] + glstate->list.base); break
 
     // seriously wtf
     #define call_bytes(name, stride)                             \


### PR DESCRIPTION
#364 was closed but not completely fixed. This fixes the last undefined symbol error.