### PR TITLE
Export eglDestroySyncKHR symbols.

### DIFF
--- a/src/egl/egl.c
+++ b/src/egl/egl.c
@@ -204,6 +204,11 @@ EGLSyncKHR gl4es_eglCreateSyncKHR(EGLDisplay dpy, EGLenum type, const EGLint *at
     return egl_eglCreateSyncKHR(dpy, type, attrib_list);
 }
 
+EGLSyncKHR gl4es_eglDestroySyncKHR(EGLDisplay dpy, EGLSyncKHR sync) {
+    LOAD_EGL(eglDestroySyncKHR);
+    return egl_eglDestroySyncKHR(dpy, sync);
+}
+
 EGLint gl4es_eglClientWaitSyncKHR(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout) {
     LOAD_EGL(eglClientWaitSyncKHR);
     return egl_eglClientWaitSyncKHR(dpy, sync, flags, timeout);
@@ -257,6 +262,7 @@ AliasExport(EGLBoolean, eglWaitNative,,(EGLint engine));
 AliasExport(EGLBoolean, eglSwapBuffers,,(EGLDisplay dpy, EGLSurface surface));
 AliasExport(EGLBoolean, eglCopyBuffers,,(EGLDisplay dpy, EGLSurface surface, EGLNativePixmapType target));
 AliasExport(EGLSyncKHR, eglCreateSyncKHR,,(EGLDisplay dpy, EGLenum type, const EGLint *attrib_list));
+AliasExport(EGLSyncKHR, eglDestroySyncKHR,,(EGLDisplay dpy, EGLSyncKHR sync));
 AliasExport(EGLint, eglClientWaitSyncKHR,,(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout));
 
 AliasExport(NativePixmapType, egl_create_pixmap_ID_mapping,,(void *pixmap));

--- a/src/egl/egl.h
+++ b/src/egl/egl.h
@@ -49,6 +49,7 @@ EGLBoolean gl4es_eglCopyBuffers(EGLDisplay dpy, EGLSurface surface, EGLNativePix
 void* gl4es_eglGetProcAddress(const char *name);
 
 EGLSyncKHR gl4es_eglCreateSyncKHR(EGLDisplay dpy, EGLenum type, const EGLint *attrib_list);
+EGLSyncKHR gl4es_eglDestroySyncKHR(EGLDisplay dpy, EGLSyncKHR sync);
 EGLint gl4es_eglClientWaitSyncKHR(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout);
 
 // Undocumented libmali internals, needed for ODROID Go Ultra

--- a/src/egl/lookup.c
+++ b/src/egl/lookup.c
@@ -55,6 +55,7 @@ void* gl4es_eglGetProcAddress(const char *name) {
     _EX(eglSwapBuffers);
     _EX(eglCopyBuffers);
     _EX(eglCreateSyncKHR);
+    _EX(eglDestroySyncKHR);
     _EX(eglClientWaitSyncKHR);
 
     _EX(egl_create_pixmap_ID_mapping);

--- a/src/gl/loader.h
+++ b/src/gl/loader.h
@@ -50,6 +50,7 @@ typedef EGLBoolean (*eglWaitClient_PTR)();
 typedef EGLBoolean (*eglWaitGL_PTR)();
 typedef EGLBoolean (*eglWaitNative_PTR)(EGLint engine);
 typedef EGLSyncKHR (*eglCreateSyncKHR_PTR)(EGLDisplay dpy, EGLenum type, const EGLint * attrib_list);
+typedef EGLSyncKHR (*eglDestroySyncKHR_PTR)(EGLDisplay dpy, EGLSyncKHR sync);
 typedef EGLint (*eglClientWaitSyncKHR_PTR)(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout);
 
 typedef NativePixmapType (*egl_create_pixmap_ID_mapping_PTR)(void *pixmap);


### PR DESCRIPTION
Needed by mali-fbdev SDL2 backend for certain sunxi h700 devices (rg28xx, rg40xx).