### PR TITLE
DEFAULT_GLES, DEFAULT_EGL, LIBGL_FB compile defines

### DIFF
--- a/src/gl/enable.c
+++ b/src/gl/enable.c
@@ -87,7 +87,7 @@ static void proxy_glEnable(GLenum cap, bool enable, void (APIENTRY_GLES *next)(G
         if (!glstate->texture.bound[glstate->texture.active][ENABLED_TEX2D]->alpha)
             enable = false;
     }
-	noerrorShim();
+    noerrorShim();
 #ifdef TEXSTREAM
     if (cap==GL_TEXTURE_STREAM_IMG) {
         FLUSH_BEGINEND;
@@ -163,7 +163,7 @@ static void proxy_glEnable(GLenum cap, bool enable, void (APIENTRY_GLES *next)(G
         //cannot use clientGO_proxyFPE here, has the ClientArray are really enabled / disabled elsewhere in fact (inside glDraw or list_draw)
         clientGO(GL_SECONDARY_COLOR_ARRAY, vertexattrib[ATT_SECONDARY].enabled);
         clientGO(GL_FOG_COORD_ARRAY, vertexattrib[ATT_FOGCOORD].enabled);
-	
+    
         // for glDrawArrays
         clientGO(GL_VERTEX_ARRAY, vertexattrib[ATT_VERTEX].enabled);
         clientGO(GL_NORMAL_ARRAY, vertexattrib[ATT_NORMAL].enabled);
@@ -270,17 +270,17 @@ static void proxy_glEnable(GLenum cap, bool enable, void (APIENTRY_GLES *next)(G
 void APIENTRY_GL4ES gl4es_glEnable(GLenum cap) {
     DBG(printf("glEnable(%s), glstate->list.pending=%d\n", PrintEnum(cap), glstate->list.pending);)
     if(!glstate->list.pending) {
-	    PUSH_IF_COMPILING(glEnable)
+        PUSH_IF_COMPILING(glEnable)
     }
 #ifdef TEXSTREAM00
-	if (globals4es.texstream && (cap==GL_TEXTURE_2D)) {
+    if (globals4es.texstream && (cap==GL_TEXTURE_2D)) {
         if (glstate->texture.bound[glstate->texture.active][ENABLED_TEX2D]->streamed)
             cap = GL_TEXTURE_STREAM_IMG;
-	}
-	if (globals4es.texstream && (cap==GL_TEXTURE_RECTANGLE_ARB)) {
+    }
+    if (globals4es.texstream && (cap==GL_TEXTURE_RECTANGLE_ARB)) {
         if (glstate->texture.bound[glstate->texture.active][ENABLED_TEXTURE_RECTANGLE]->streamed)
             cap = GL_TEXTURE_STREAM_IMG;
-	}
+    }
 #endif
     LOAD_GLES(glEnable);
     proxy_glEnable(cap, true, gles_glEnable);
@@ -290,18 +290,18 @@ AliasExport(void,glEnable,,(GLenum cap));
 void APIENTRY_GL4ES gl4es_glDisable(GLenum cap) {
     DBG(printf("glDisable(%s), glstate->list.pending=%d\n", PrintEnum(cap), glstate->list.pending);)
     if(!glstate->list.pending) {
-	    PUSH_IF_COMPILING(glDisable)
+        PUSH_IF_COMPILING(glDisable)
     }
         
 #ifdef TEXSTREAM00
-	if (globals4es.texstream && (cap==GL_TEXTURE_2D)) {
+    if (globals4es.texstream && (cap==GL_TEXTURE_2D)) {
         if (glstate->texture.bound[glstate->texture.active][ENABLED_TEX2D]->streamed)
             cap = GL_TEXTURE_STREAM_IMG;
-	}
-	if (globals4es.texstream && (cap==GL_TEXTURE_RECTANGLE_ARB)) {
+    }
+    if (globals4es.texstream && (cap==GL_TEXTURE_RECTANGLE_ARB)) {
         if (glstate->texture.bound[glstate->texture.active][ENABLED_TEXTURE_RECTANGLE]->streamed)
             cap = GL_TEXTURE_STREAM_IMG;
-	}
+    }
 #endif
     LOAD_GLES(glDisable);
     proxy_glEnable(cap, false, gles_glDisable);
@@ -341,7 +341,7 @@ GLboolean APIENTRY_GL4ES gl4es_glIsEnabled(GLenum cap) {
     // should flush for now... but no need if it's just a pending list...
     if (glstate->list.active && !glstate->list.pending)
         gl4es_flush();
-    LOAD_GLES(glIsEnabled);
+    GLboolean gles_glIsEnabled(glIsEnabled_ARG_EXPAND); //LOAD_GLES(glIsEnabled);
     noerrorShim();
     switch (cap) {
         isenabled(GL_AUTO_NORMAL, auto_normal);
@@ -357,7 +357,7 @@ GLboolean APIENTRY_GL4ES gl4es_glIsEnabled(GLenum cap) {
         isenabled(GL_TEXTURE_GEN_R, texgen_r[glstate->texture.active]);
         isenabled(GL_TEXTURE_GEN_Q, texgen_q[glstate->texture.active]);
         isenabled(GL_COLOR_MATERIAL, color_material);
-		isenabled(GL_COLOR_SUM, color_sum);
+        isenabled(GL_COLOR_SUM, color_sum);
         isenabled(GL_POINT_SPRITE, pointsprite);
         isenabled(GL_PROGRAM_POINT_SIZE, point_size);
         isenabled(GL_CLIP_PLANE0, plane[0]);
@@ -417,7 +417,7 @@ GLboolean APIENTRY_GL4ES gl4es_glIsEnabled(GLenum cap) {
         isenabled(GL_VERTEX_PROGRAM_ARB, vertex_arb);
         isenabled(GL_VERTEX_PROGRAM_TWO_SIDE_ARB, vertex_two_side_arb);
         default:
-			errorGL();
+            errorGL();
             return gles_glIsEnabled(cap);
     }
 }

--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -16,13 +16,10 @@
 #include "logs.h"
 
 #define fpe_state_t struct fpe_state_s
-#define fpe_fpe_t struct fpe_fpe_t_s
 #define kh_fpecachelist_t struct kh_fpecachelist_s
 #include "fpe_cache.h"
-#undef fpe_state_t
 #undef fpe_fpe_t
 #undef kh_fpecachelist_t
-
 #include "init.h"
 #include "envvars.h"
 #if defined(__EMSCRIPTEN__) || defined(__APPLE__)

--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -14,12 +14,7 @@
 #include "debug.h"
 #include "loader.h"
 #include "logs.h"
-
-#define fpe_state_t struct fpe_state_s
-#define kh_fpecachelist_t struct kh_fpecachelist_s
 #include "fpe_cache.h"
-#undef fpe_fpe_t
-#undef kh_fpecachelist_t
 #include "init.h"
 #include "envvars.h"
 #if defined(__EMSCRIPTEN__) || defined(__APPLE__)
@@ -127,15 +122,13 @@ void initialize_gl4es() {
     env(LIBGL_STACKTRACE, globals4es.stacktrace, "stacktrace will be printed on crash");
 
     const int LIBGL_FB_ENV_VAR = 
-	    ReturnEnvVarInt("LIBGL_FB");
-	const int LIBGL_FB_VALUE = 
 #       ifndef LIBGL_FB
-        LIBGL_FB_ENV_VAR
+        ReturnEnvVarInt("LIBGL_FB")
 #       else
-        0 == LIBGL_FB_ENV_VAR ? LIBGL_FB : 0
+        ReturnEnvVarIntDef("LIBGL_FB", LIBGL_FB)
 #       endif
     ;
-    switch(LIBGL_FB_VALUE) {
+    switch(LIBGL_FB_ENV_VAR) {
         case 1:
         SHUT_LOGD("framebuffer output enabled\n");
         globals4es.usefb = 1;

--- a/src/gl/texture.c
+++ b/src/gl/texture.c
@@ -921,7 +921,7 @@ void APIENTRY_GL4ES gl4es_glTexImage2D(GLenum target, GLint level, GLint interna
     const GLuint rtarget = map_tex_target(target);
     LOAD_GLES(glTexImage2D);
     LOAD_GLES(glTexSubImage2D);
-    LOAD_GLES(glTexParameteri);
+    void gles_glTexParameteri(glTexParameteri_ARG_EXPAND); //LOAD_GLES(glTexParameteri);
 
     if(globals4es.force16bits) {
         if(internalformat==GL_RGBA || internalformat==4 || internalformat==GL_RGBA8)
@@ -966,7 +966,7 @@ void APIENTRY_GL4ES gl4es_glTexImage2D(GLenum target, GLint level, GLint interna
         datab = (char*)datab + (uintptr_t)glstate->vao->unpack->data;
         
     GLvoid *pixels = (GLvoid *)datab;
-    border = 0;	//TODO: something?
+    border = 0;    //TODO: something?
     noerrorShim();
 
     gltexture_t *bound = glstate->texture.bound[glstate->texture.active][itarget];
@@ -1086,7 +1086,7 @@ void APIENTRY_GL4ES gl4es_glTexImage2D(GLenum target, GLint level, GLint interna
     if (globals4es.automipmap) {
         if (level>0)
             if ((globals4es.automipmap==1) || (globals4es.automipmap==3) || bound->mipmap_need) {
-                return;			// has been handled by auto_mipmap
+                return;            // has been handled by auto_mipmap
             }
             else if(globals4es.automipmap==2)
                 bound->mipmap_need = 1;
@@ -1219,7 +1219,7 @@ void APIENTRY_GL4ES gl4es_glTexImage2D(GLenum target, GLint level, GLint interna
         if (globals4es.texstream && (target==GL_TEXTURE_2D || target==GL_TEXTURE_RECTANGLE_ARB) && (width>=256 && height>=224) && 
         ((internalformat==GL_RGB) || (internalformat==3) || (internalformat==GL_RGB8) || (internalformat==GL_BGR) || (internalformat==GL_RGB5) || (internalformat==GL_RGB565)) || (globals4es.texstream==2) ) {
             bound->streamingID = AddStreamed(width, height, bound->texture);
-            if (bound->streamingID>-1) {	// success
+            if (bound->streamingID>-1) {    // success
                 bound->shrink = 0;  // no shrink on Stream texture
                 bound->streamed = true;
                 glsampler_t *sampler = glstate->samplers.sampler[glstate->texture.active];
@@ -1231,7 +1231,7 @@ void APIENTRY_GL4ES gl4es_glTexImage2D(GLenum target, GLint level, GLint interna
                 LOAD_GLES(glEnable);
                 if (tmp)
                     gles_glDisable(GL_TEXTURE_2D);
-                ActivateStreaming(bound->streamingID);	//Activate the newly created texture
+                ActivateStreaming(bound->streamingID);    //Activate the newly created texture
                 format = GL_RGB;
                 type = GL_UNSIGNED_SHORT_5_6_5;
                 if (tmp)
@@ -1241,7 +1241,7 @@ void APIENTRY_GL4ES gl4es_glTexImage2D(GLenum target, GLint level, GLint interna
         }
 #endif
         if (!bound->streamed)
-            swizzle_texture(width, height, &format, &type, internalformat, new_format, NULL, bound);	// convert format even if data is NULL
+            swizzle_texture(width, height, &format, &type, internalformat, new_format, NULL, bound);    // convert format even if data is NULL
         if (bound->shrink!=0) {
             switch(globals4es.texshrink) {
             case 1: //everything / 2
@@ -1506,7 +1506,7 @@ void APIENTRY_GL4ES gl4es_glTexImage2D(GLenum target, GLint level, GLint interna
             gles_glTexParameteri( rtarget, GL_GENERATE_MIPMAP, GL_FALSE );*/
         } else {
             if (pixels)
-                gl4es_glTexSubImage2D(rtarget, level, 0, 0, width, height, format, type, pixels);	// (should never happens) updload the 1st data...
+                gl4es_glTexSubImage2D(rtarget, level, 0, 0, width, height, format, type, pixels);    // (should never happens) updload the 1st data...
         }
         if(bound->mipmap_need && !bound->mipmap_done) {
             if(bound->mipmap_auto)
@@ -1563,7 +1563,7 @@ void APIENTRY_GL4ES gl4es_glTexSubImage2D(GLenum target, GLint level, GLint xoff
     const GLuint rtarget = map_tex_target(target);
 
     LOAD_GLES(glTexSubImage2D);
-    LOAD_GLES(glTexParameteri);
+    void gles_glTexParameteri(glTexParameteri_ARG_EXPAND); //LOAD_GLES(glTexParameteri);
     noerrorShim();
     DBG(printf("glTexSubImage2D on target=%s with unpack_row_length(%d), size(%d,%d), pos(%d,%d) and skip={%d,%d}, format=%s, type=%s, level=%d(base=%d, max=%d), mipmap={need=%d, auto=%d}, texture=%u, data=%p(vao=%p)\n", PrintEnum(target), glstate->texture.unpack_row_length, width, height, xoffset, yoffset, glstate->texture.unpack_skip_pixels, glstate->texture.unpack_skip_rows, PrintEnum(format), PrintEnum(type), level, glstate->texture.bound[glstate->texture.active][itarget]->base_level, glstate->texture.bound[glstate->texture.active][itarget]->max_level, glstate->texture.bound[glstate->texture.active][itarget]->mipmap_need, glstate->texture.bound[glstate->texture.active][itarget]->mipmap_auto, glstate->texture.bound[glstate->texture.active][itarget]->texture, data, glstate->vao->unpack);)
     if (width==0 || height==0) {
@@ -1574,7 +1574,7 @@ void APIENTRY_GL4ES gl4es_glTexSubImage2D(GLenum target, GLint level, GLint xoff
     if (globals4es.automipmap) {
         if (level>0)
             if ((globals4es.automipmap==1) || (globals4es.automipmap==3) || bound->mipmap_need) {
-                return;			// has been handled by auto_mipmap
+                return;            // has been handled by auto_mipmap
             }
             else
                 bound->mipmap_need = 1;
@@ -1695,7 +1695,7 @@ void APIENTRY_GL4ES gl4es_glTexSubImage2D(GLenum target, GLint level, GLint xoff
     }
     
     if (globals4es.texstream && bound->streamed) {
-/*	// copy the texture to the buffer
+/*    // copy the texture to the buffer
     void* tmp = GetStreamingBuffer(bound->streamingID);
     for (int yy=0; yy<height; yy++) {
         memcpy(tmp+((yy+yoffset)*bound->width+xoffset)*2, pixels+(yy*width)*2, width*2);

--- a/src/gl/texture_params.c
+++ b/src/gl/texture_params.c
@@ -305,12 +305,12 @@ void APIENTRY_GL4ES gl4es_glTexParameterfv(GLenum target, GLenum pname, const GL
             case GL_TEXTURE_MAX_LEVEL:
                 if (texture)
                     texture->max_level = param;
-                return;			// not on GLES
+                return;            // not on GLES
             case GL_TEXTURE_BASE_LEVEL:
                 texture->base_level = param;
-                return;			// not on GLES
+                return;            // not on GLES
             case GL_TEXTURE_LOD_BIAS:
-                return;			// not on GLES
+                return;            // not on GLES
             case GL_GENERATE_MIPMAP:
                 if(globals4es.automipmap==3)
                     return; // no mipmap, so no need to generate any
@@ -592,7 +592,7 @@ void APIENTRY_GL4ES gl4es_glGetTexLevelParameterfv(GLenum target, GLint level, G
                 break;
 
             default:
-                errorShim(GL_INVALID_ENUM);	//Wrong here...
+                errorShim(GL_INVALID_ENUM);    //Wrong here...
                 printf("Stubbed glGetTexLevelParameteriv(%s, %i, %s, %p)\n", PrintEnum(target), level, PrintEnum(pname), params);
         }
     }
@@ -768,7 +768,7 @@ void realize_1texture(GLenum target, int wantedTMU, gltexture_t* tex, glsampler_
 {
     DBG(printf("realize_1texture(%s, %d, %p[%u], %p)\n", PrintEnum(target), wantedTMU, tex, tex->glname, sampler);)
     LOAD_GLES(glActiveTexture);
-    LOAD_GLES(glTexParameteri);
+    void gles_glTexParameteri(glTexParameteri_ARG_EXPAND); //LOAD_GLES(glTexParameteri);
     LOAD_GLES(glBindTexture);
     // check sampler stuff
     if(!sampler) sampler = &tex->sampler;
@@ -853,7 +853,7 @@ void realize_textures(int drawing) {
     LOAD_GLES(glDisable);
     LOAD_GLES(glBindTexture);
     LOAD_GLES(glActiveTexture);
-    LOAD_GLES(glTexParameteri);
+    void gles_glTexParameteri(glTexParameteri_ARG_EXPAND); //LOAD_GLES(glTexParameteri);
 #ifdef TEXSTREAM
     DBG(printf("realize_textures(%d), glstate->bound_changed=%d, glstate->enable.texture[0]=%X glsate->actual_tex2d[0]=%u / glstate->bound_stream[0]=%u\n", drawing, glstate->bound_changed, glstate->enable.texture[0], glstate->actual_tex2d[0], glstate->bound_stream[0]);)
 #else

--- a/src/gl/wrap/gles.c
+++ b/src/gl/wrap/gles.c
@@ -2,6 +2,40 @@
 #include "../gl4es.h"
 #include "../loader.h"
 #include "skips.h"
+
+// emulation of 'glTexParameteri' (for internal use only)
+void gles_glTexParameteri(glTexParameteri_ARG_EXPAND)
+{
+    LOAD_GLES(glTexParameteri); if (gles_glTexParameteri) return gles_glTexParameteri(target, pname, param);
+
+    LOAD_GLES(glTexParameterx);
+
+    return gles_glTexParameterx(target, pname, param);
+}
+
+// emulation of 'glGetBooleanv' (for internal use only)
+void gles_glGetBooleanv(glGetBooleanv_ARG_EXPAND)
+{
+    LOAD_GLES(glGetBooleanv); if (gles_glGetBooleanv) return gles_glGetBooleanv(pname, params);
+
+    LOAD_GLES(glGetIntegerv);
+
+    GLint result = GL_FALSE;
+    gles_glGetIntegerv(pname, &result);
+    if (params) *params = (result == GL_TRUE ? GL_TRUE : GL_FALSE);
+}
+
+// emulation of 'glIsEnabled' (for internal use only)
+GLboolean gles_glIsEnabled(glIsEnabled_ARG_EXPAND)
+{
+    LOAD_GLES(glIsEnabled); if (gles_glIsEnabled) return gles_glIsEnabled(cap);
+
+    GLboolean result = GL_FALSE;
+
+    gles_glGetBooleanv(cap, &result);
+    return result;
+}
+
 #ifndef skip_glActiveTexture
 void APIENTRY_GL4ES gl4es_glActiveTexture(GLenum texture) {
     LOAD_GLES(glActiveTexture);
@@ -844,7 +878,7 @@ AliasExport(GLint,glGetAttribLocation,,(GLuint program, const GLchar * name));
 #endif
 #ifndef skip_glGetBooleanv
 void APIENTRY_GL4ES gl4es_glGetBooleanv(GLenum pname, GLboolean * params) {
-    LOAD_GLES(glGetBooleanv);
+    void gles_glGetBooleanv(glGetBooleanv_ARG_EXPAND); //LOAD_GLES(glGetBooleanv);
 #ifndef direct_glGetBooleanv
     PUSH_IF_COMPILING(glGetBooleanv)
 #endif
@@ -1214,7 +1248,7 @@ AliasExport(GLboolean,glIsBuffer,,(GLuint buffer));
 #endif
 #ifndef skip_glIsEnabled
 GLboolean APIENTRY_GL4ES gl4es_glIsEnabled(GLenum cap) {
-    LOAD_GLES(glIsEnabled);
+    GLboolean gles_glIsEnabled(glIsEnabled_ARG_EXPAND); //LOAD_GLES(glIsEnabled);
 #ifndef direct_glIsEnabled
     PUSH_IF_COMPILING(glIsEnabled)
 #endif
@@ -2024,7 +2058,7 @@ AliasExport(void,glTexParameterfv,,(GLenum target, GLenum pname, const GLfloat *
 #endif
 #ifndef skip_glTexParameteri
 void APIENTRY_GL4ES gl4es_glTexParameteri(GLenum target, GLenum pname, GLint param) {
-    LOAD_GLES(glTexParameteri);
+    void gles_glTexParameteri(glTexParameteri_ARG_EXPAND); //LOAD_GLES(glTexParameteri);
 #ifndef direct_glTexParameteri
     PUSH_IF_COMPILING(glTexParameteri)
 #endif


### PR DESCRIPTION
+ DEFAULT_GLES, DEFAULT_EGL compile defines for loader to let user build with extra non-common GLES and EGL lib names
* Changed tabs->spaces for consistency
+ LIBGL_FB compile define used if user has not set env variable - allow to define default LIBGL_FB value at compile time
* added defines to fix older C99 errors about struct typedef redefinitions
* added missing implementations of gl functions: `glTexParameteri`, `glGetBooleanv`, `glIsEnabled`