### PR TITLE
resolving typedef errors for C99 and add EGL support for QNX NTO

### DIFF
--- a/include/EGL/eglplatform.h
+++ b/include/EGL/eglplatform.h
@@ -152,6 +152,10 @@ typedef void              *EGLNativeDisplayType;
 typedef khronos_uintptr_t  EGLNativePixmapType;
 typedef khronos_uintptr_t  EGLNativeWindowType;
 
+#elif defined(__QNXNTO__)
+typedef struct _gf_dev* EGLNativeDisplayType;
+typedef void* EGLNativeWindowType;
+typedef void* EGLNativePixmapType;
 #else
 #error "Platform not recognized"
 #endif

--- a/src/gl/fpe.c
+++ b/src/gl/fpe.c
@@ -10,8 +10,20 @@
 #include "matvec.h"
 #include "program.h"
 #include "shaderconv.h"
-#include "fpe_cache.h"
+
 #include "fpe.h"
+
+#define fpe_state_t fpe_state_t
+#define fpe_fpe_t fpe_fpe_t
+#define kh_fpecachelist_t kh_fpecachelist_t
+#include "fpe_cache.h"
+#undef fpe_state_t
+#undef fpe_fpe_t
+#undef kh_fpecachelist_t
+
+#ifndef fpe_cache_t
+#   define fpe_cache_t kh_fpecachelist_t
+#endif
 
 //#define DEBUG
 #ifdef DEBUG

--- a/src/gl/fpe.h
+++ b/src/gl/fpe.h
@@ -226,7 +226,9 @@ typedef struct fpe_fpe_s {
   program_t *glprogram;
 } fpe_fpe_t;
 
+#ifndef kh_fpecachelist_t
 typedef struct kh_fpecachelist_s kh_fpecachelist_t;
+#endif
 #define fpe_cache_t kh_fpecachelist_t
 
 typedef struct scratch_s {
@@ -234,7 +236,6 @@ typedef struct scratch_s {
     int         size;
 } scratch_t;
 void free_scratch(scratch_t* scratch);
-
 
 fpe_fpe_t *fpe_GetCache(fpe_cache_t *cur, fpe_state_t *state, int fixed);
 void fpe_disposeCache(fpe_cache_t* cache, int freeprog);

--- a/src/gl/fpe_cache.c
+++ b/src/gl/fpe_cache.c
@@ -6,8 +6,21 @@
 #include "logs.h"
 #include "debug.h"
 #include "program.h"
-#include "fpe_cache.h"
+
 #include "fpe.h"
+
+
+#define fpe_state_t fpe_state_t
+#define fpe_fpe_t fpe_fpe_t
+#define kh_fpecachelist_t kh_fpecachelist_t
+#include "fpe_cache.h"
+#undef fpe_state_t
+#undef fpe_fpe_t
+#undef kh_fpecachelist_t
+
+#ifndef fpe_cache_t
+#   define fpe_cache_t kh_fpecachelist_t
+#endif
 
 //#define DEBUG
 #ifdef DEBUG
@@ -23,19 +36,21 @@ static const char PSA_SIGN[] = "GL4ES PrecompiledShaderArchive";
 static kh_inline khint_t _hash_fpe(fpe_state_t *p)
 {
     const char* s = (const char*)p;
-	khint_t h = (khint_t)*s;
-	for (int i=1 ; i<sizeof(fpe_state_t); ++i) h = (h << 5) - h + (khint_t)*(++s);
-	return h;
+    khint_t h = (khint_t)*s;
+    for (int i=1 ; i<sizeof(fpe_state_t); ++i) h = (h << 5) - h + (khint_t)*(++s);
+    return h;
 }
 
 #define kh_fpe_hash_func(key) _hash_fpe(key)
 
 #define kh_fpe_hash_equal(a, b) (memcmp(a, b, sizeof(fpe_state_t)) == 0)
 
-#define KHASH_MAP_INIT_FPE(name, khval_t)								\
-	KHASH_INIT(name, kh_fpe_t, khval_t, 1, kh_fpe_hash_func, kh_fpe_hash_equal)
+#define KHASH_MAP_INIT_FPE(name, khval_t)                                \
+    KHASH_INIT(name, kh_fpe_t, khval_t, 1, kh_fpe_hash_func, kh_fpe_hash_equal)
 
+#define kh_fpecachelist_t kh_fpecachelist_s
 KHASH_MAP_INIT_FPE(fpecachelist, fpe_fpe_t *);
+#undef kh_fpecachelist_t
 
 // ********* Cache handling *********
 

--- a/src/gl/fpe_cache.h
+++ b/src/gl/fpe_cache.h
@@ -1,10 +1,35 @@
 #ifndef __FPE_CACHE_H__
 #define __FPE_CACHE_H__
 
+#ifdef _GL4ES_FPE_H_ // there is fpe.h with typedefs already
+#   ifndef fpe_state_t 
+#   define fpe_state_t fpe_state_t
+#   define DO_NOT_FORGET_TO_UNDEF_fpe_state_t
+#   endif
+#   ifndef fpe_fpe_t 
+#   define fpe_fpe_t fpe_fpe_t
+#   define DO_NOT_FORGET_TO_UNDEF_fpe_fpe_t
+#   endif
+#   ifndef kh_fpecachelist_t 
+#   define kh_fpecachelist_t kh_fpecachelist_t
+#   define DO_NOT_FORGET_TO_UNDEF_kh_fpecachelist_t
+#   endif
+#   ifndef fpe_cache_t 
+#   define fpe_cache_t kh_fpecachelist_t
+#   define DO_NOT_FORGET_TO_UNDEF_fpe_cache_t
+#   endif
+#endif // _GL4ES_FPE_H_
+
+#ifndef fpe_state_t
 typedef struct fpe_state_s fpe_state_t;
+#endif
 typedef fpe_state_t *kh_fpe_t;
+#ifndef fpe_fpe_t
 typedef struct fpe_fpe_s fpe_fpe_t;
+#endif
+#ifndef kh_fpecachelist_t
 typedef struct kh_fpecachelist_s kh_fpecachelist_t;
+#endif
 #ifndef fpe_cache_t
 #define fpe_cache_t kh_fpecachelist_t
 #endif
@@ -19,5 +44,22 @@ void fpe_readPSA();
 void fpe_writePSA();
 int fpe_GetProgramPSA(GLuint program, fpe_state_t* state);
 void fpe_AddProgramPSA(GLuint program, fpe_state_t* state);
+
+#ifdef DO_NOT_FORGET_TO_UNDEF_fpe_state_t 
+#undef fpe_state_t
+#undef DO_NOT_FORGET_TO_UNDEF_fpe_state_t
+#endif
+#ifdef DO_NOT_FORGET_TO_UNDEF_fpe_fpe_t 
+#undef fpe_fpe_t
+#undef DO_NOT_FORGET_TO_UNDEF_fpe_fpe_t
+#endif
+#ifdef DO_NOT_FORGET_TO_UNDEF_kh_fpecachelist_t 
+#undef kh_fpecachelist_t
+#undef DO_NOT_FORGET_TO_UNDEF_kh_fpecachelist_t
+#endif
+#ifdef DO_NOT_FORGET_TO_UNDEF_fpe_cache_t 
+#undef fpe_cache_t
+#undef DO_NOT_FORGET_TO_UNDEF_fpe_cache_t
+#endif
 
 #endif //__FPE_CACHE_H__

--- a/src/gl/framebuffers.c
+++ b/src/gl/framebuffers.c
@@ -48,31 +48,31 @@ glframebuffer_t* get_framebuffer(GLenum target) {
 
 
 void readfboBegin() {
-	if (glstate->fbo.fbo_read == glstate->fbo.fbo_draw)
+    if (glstate->fbo.fbo_read == glstate->fbo.fbo_draw)
         return;
     DBG(printf("readfboBegin, fbo status read=%u, draw=%u, main=%u, current=%u\n", glstate->fbo.fbo_read->id, glstate->fbo.fbo_draw->id, glstate->fbo.mainfbo_fbo, glstate->fbo.current_fb->id);)
     if(glstate->fbo.fbo_read==glstate->fbo.current_fb)
         return;
     glstate->fbo.current_fb = glstate->fbo.fbo_read;
-	GLuint fbo = glstate->fbo.fbo_read->id;
-	if (!fbo)
-		fbo = glstate->fbo.mainfbo_fbo;
+    GLuint fbo = glstate->fbo.fbo_read->id;
+    if (!fbo)
+        fbo = glstate->fbo.mainfbo_fbo;
     LOAD_GLES2_OR_OES(glBindFramebuffer);
-	gles_glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    gles_glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 }
 
 void readfboEnd() {
-	if (glstate->fbo.fbo_read->id == glstate->fbo.fbo_draw->id)
+    if (glstate->fbo.fbo_read->id == glstate->fbo.fbo_draw->id)
         return;
     DBG(printf("readfboEnd, fbo status read=%p, draw=%p, main=%u, current=%p\n", glstate->fbo.fbo_read, glstate->fbo.fbo_draw, glstate->fbo.mainfbo_fbo, glstate->fbo.current_fb);)
     if(glstate->fbo.fbo_draw==glstate->fbo.current_fb)
         return;
     glstate->fbo.current_fb = glstate->fbo.fbo_draw;
-	GLuint fbo = glstate->fbo.fbo_draw->id;
-	if (!fbo)
-		fbo = glstate->fbo.mainfbo_fbo;
+    GLuint fbo = glstate->fbo.fbo_draw->id;
+    if (!fbo)
+        fbo = glstate->fbo.mainfbo_fbo;
     LOAD_GLES2_OR_OES(glBindFramebuffer);
-	gles_glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    gles_glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 }
 
 glrenderbuffer_t* find_renderbuffer(GLuint renderbuffer) {
@@ -219,7 +219,7 @@ GLenum APIENTRY_GL4ES gl4es_glCheckFramebufferStatus(GLenum target) {
 
 void APIENTRY_GL4ES gl4es_glBindFramebuffer(GLenum target, GLuint framebuffer) {
     DBG(printf("glBindFramebuffer(%s, %u), list=%s, glstate->fbo.current_fb=%d (draw=%d, read=%d)\n", PrintEnum(target), framebuffer, glstate->list.active?"active":"none", glstate->fbo.current_fb->id, glstate->fbo.fbo_draw->id, glstate->fbo.fbo_read->id);)
-	PUSH_IF_COMPILING(glBindFramebuffer);
+    PUSH_IF_COMPILING(glBindFramebuffer);
     LOAD_GLES2_OR_OES(glBindFramebuffer);
 //    LOAD_GLES2_OR_OES(glCheckFramebufferStatus);
     LOAD_GLES(glGetError);
@@ -236,17 +236,17 @@ void APIENTRY_GL4ES gl4es_glBindFramebuffer(GLenum target, GLuint framebuffer) {
     }
     
     if (target == GL_READ_FRAMEBUFFER) {
-		glstate->fbo.fbo_read = fb;
+        glstate->fbo.fbo_read = fb;
         noerrorShim();
         glstate->fbo.fb_status = GL_FRAMEBUFFER_COMPLETE;
         glstate->fbo.internal = 1;
-		return;	//don't bind for now
-	} else glstate->fbo.internal = 0;
+        return;    //don't bind for now
+    } else glstate->fbo.internal = 0;
         
     if (target == GL_DRAW_FRAMEBUFFER) {
-		target = GL_FRAMEBUFFER;
-		glstate->fbo.fbo_draw = fb;
-	}
+        target = GL_FRAMEBUFFER;
+        glstate->fbo.fbo_draw = fb;
+    }
     
     if (target != GL_FRAMEBUFFER) {
         errorShim(GL_INVALID_ENUM);
@@ -432,7 +432,7 @@ void APIENTRY_GL4ES gl4es_glFramebufferTexture2D(GLenum target, GLenum attachmen
     LOAD_GLES(glTexImage2D);
     LOAD_GLES(glBindTexture);
     LOAD_GLES(glActiveTexture);
-    LOAD_GLES(glTexParameteri);
+    void gles_glTexParameteri(glTexParameteri_ARG_EXPAND); //LOAD_GLES(glTexParameteri);
 
     glframebuffer_t *fb = get_framebuffer(target);
     if(!fb) {
@@ -782,7 +782,7 @@ void APIENTRY_GL4ES gl4es_glFramebufferTexture2D(GLenum target, GLenum attachmen
     twidth = twidth >> level; if(twidth<1) twidth=1;
     theight = theight >> level; if(theight<1) theight=1;
     
-	if (level!=0) {
+    if (level!=0) {
         //bind a scrap texture, we don't want level != 0 binding on GLES
         if(!scrap_tex)
             gl4es_glGenTextures(1, &scrap_tex);
@@ -807,10 +807,10 @@ void APIENTRY_GL4ES gl4es_glFramebufferTexture2D(GLenum target, GLenum attachmen
     ReadDraw_Pop(target);
 }
 
-void APIENTRY_GL4ES gl4es_glFramebufferTexture1D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level) {
+void APIENTRY_GL4ES gl4es_glFramebufferTexture1D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level) {
     gl4es_glFramebufferTexture2D(target, attachment, textarget, texture, level);
 }
-void APIENTRY_GL4ES gl4es_glFramebufferTexture3D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level, GLint layer) {
+void APIENTRY_GL4ES gl4es_glFramebufferTexture3D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level, GLint layer) {
     (void)layer;
     gl4es_glFramebufferTexture2D(target, attachment, textarget, texture, level);
 }
@@ -1219,7 +1219,7 @@ void createMainFBO(int width, int height) {
     LOAD_GLES(glGenTextures);
     LOAD_GLES(glBindTexture);
     LOAD_GLES(glActiveTexture);
-    LOAD_GLES(glTexParameteri);
+    void gles_glTexParameteri(glTexParameteri_ARG_EXPAND); //LOAD_GLES(glTexParameteri);
     LOAD_GLES2(glClientActiveTexture);
     LOAD_GLES(glClear);
 
@@ -1245,7 +1245,7 @@ void createMainFBO(int width, int height) {
 
     // create the texture
     if(createIt)
-	    gles_glGenTextures(1, &glstate->fbo.mainfbo_tex);
+        gles_glGenTextures(1, &glstate->fbo.mainfbo_tex);
     gles_glBindTexture(GL_TEXTURE_2D, glstate->fbo.mainfbo_tex);
     if(createIt) {
         gles_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -1254,8 +1254,8 @@ void createMainFBO(int width, int height) {
         gles_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     }
     gles_glTexImage2D(GL_TEXTURE_2D, 0, globals4es.fbo_noalpha?GL_RGB:GL_RGBA, width, height,
-					0, globals4es.fbo_noalpha?GL_RGB:GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-	gles_glBindTexture(GL_TEXTURE_2D, 0);
+                    0, globals4es.fbo_noalpha?GL_RGB:GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    gles_glBindTexture(GL_TEXTURE_2D, 0);
     // create the render buffers
     if(createIt) {
         gles_glGenRenderbuffers(1, &glstate->fbo.mainfbo_dep);
@@ -1277,9 +1277,9 @@ void createMainFBO(int width, int height) {
     
     gles_glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, glstate->fbo.mainfbo_tex, 0);
 
-	GLenum status = gles_glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    GLenum status = gles_glCheckFramebufferStatus(GL_FRAMEBUFFER);
 
-	gles_glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    gles_glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     // Put everything back
     gles_glBindTexture(GL_TEXTURE_2D, glstate->texture.bound[0][ENABLED_TEX2D]->glname);
@@ -1383,8 +1383,8 @@ void deleteMainFBO(void *state) {
     // all done...
 }
 
-void APIENTRY_GL4ES gl4es_glFramebufferTextureLayer(	GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer) {
-    gl4es_glFramebufferTexture2D(target, attachment, GL_TEXTURE_2D, texture,	level); // Force Texture2D, ignore layer (should track?)...
+void APIENTRY_GL4ES gl4es_glFramebufferTextureLayer(    GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer) {
+    gl4es_glFramebufferTexture2D(target, attachment, GL_TEXTURE_2D, texture,    level); // Force Texture2D, ignore layer (should track?)...
 }
 
 #ifndef NOX11
@@ -1754,9 +1754,9 @@ AliasExport(void,glDeleteFramebuffers,,(GLsizei n, GLuint *framebuffers));
 AliasExport(GLboolean,glIsFramebuffer,,(GLuint framebuffer));
 AliasExport(GLenum,glCheckFramebufferStatus,,(GLenum target));
 AliasExport(void,glBindFramebuffer,,(GLenum target, GLuint framebuffer));
-AliasExport(void,glFramebufferTexture1D,,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level));
-AliasExport(void,glFramebufferTexture2D,,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level));
-AliasExport(void,glFramebufferTexture3D,,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level, GLint layer));
+AliasExport(void,glFramebufferTexture1D,,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level));
+AliasExport(void,glFramebufferTexture2D,,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level));
+AliasExport(void,glFramebufferTexture3D,,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level, GLint layer));
 AliasExport(void,glGenRenderbuffers,,(GLsizei n, GLuint *renderbuffers));
 AliasExport(void,glFramebufferRenderbuffer,,(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer));
 AliasExport(void,glDeleteRenderbuffers,,(GLsizei n, GLuint *renderbuffers));
@@ -1766,7 +1766,7 @@ AliasExport(GLboolean,glIsRenderbuffer,,(GLuint renderbuffer));
 AliasExport(void,glGenerateMipmap,,(GLenum target));
 AliasExport(void,glGetFramebufferAttachmentParameteriv,,(GLenum target, GLenum attachment, GLenum pname, GLint *params));
 AliasExport(void,glGetRenderbufferParameteriv,,(GLenum target, GLenum pname, GLint * params));
-AliasExport(void,glFramebufferTextureLayer,,(	GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer));
+AliasExport(void,glFramebufferTextureLayer,,(    GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer));
 AliasExport(void,glBlitFramebuffer,,(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter));
 
 // EXT direct wrapper
@@ -1775,9 +1775,9 @@ AliasExport(void,glDeleteFramebuffers,EXT,(GLsizei n, GLuint *framebuffers));
 AliasExport(GLboolean,glIsFramebuffer,EXT,(GLuint framebuffer));
 AliasExport(GLenum,glCheckFramebufferStatus,EXT,(GLenum target));
 AliasExport(void,glBindFramebuffer,EXT,(GLenum target, GLuint framebuffer));
-AliasExport(void,glFramebufferTexture1D,EXT,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level));
-AliasExport(void,glFramebufferTexture2D,EXT,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level));
-AliasExport(void,glFramebufferTexture3D,EXT,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,	GLint level, GLint layer));
+AliasExport(void,glFramebufferTexture1D,EXT,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level));
+AliasExport(void,glFramebufferTexture2D,EXT,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level));
+AliasExport(void,glFramebufferTexture3D,EXT,(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,    GLint level, GLint layer));
 AliasExport(void,glGenRenderbuffers,EXT,(GLsizei n, GLuint *renderbuffers));
 AliasExport(void,glFramebufferRenderbuffer,EXT,(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer));
 AliasExport(void,glDeleteRenderbuffers,EXT,(GLsizei n, GLuint *renderbuffers));
@@ -1787,7 +1787,7 @@ AliasExport(GLboolean,glIsRenderbuffer,EXT,(GLuint renderbuffer));
 AliasExport(void,glGenerateMipmap,EXT,(GLenum target));
 AliasExport(void,glGetFramebufferAttachmentParameteriv,EXT,(GLenum target, GLenum attachment, GLenum pname, GLint *params));
 AliasExport(void,glGetRenderbufferParameteriv,EXT,(GLenum target, GLenum pname, GLint * params));
-AliasExport(void,glFramebufferTextureLayer,EXT,(	GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer));
+AliasExport(void,glFramebufferTextureLayer,EXT,(    GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer));
 AliasExport(void,glBlitFramebuffer,EXT,(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter));
 
 // Multisample stub

--- a/src/gl/glstate.h
+++ b/src/gl/glstate.h
@@ -1,6 +1,7 @@
 #ifndef _GL4ES_GLSTATE_H_
 #define _GL4ES_GLSTATE_H_
 
+#include "oldprogram.h"
 #include "fog.h"
 #include "fpe.h"
 #include "light.h"
@@ -9,7 +10,7 @@
 #include "stack.h"
 #include "stencil.h"
 
-typedef struct glstate_s {
+struct glstate_s {
     int                 dummy[16];  // dummy zone, test for memory overwriting...
     displaylist_state_t list;
     enable_state_t      enable;
@@ -20,7 +21,7 @@ typedef struct glstate_s {
     texenv_state_t      texenv[MAX_TEX];
     texture_state_t     texture;
     GLboolean           colormask[4];
-    int	                render_mode;
+    int                 render_mode;
     int                 polygon_mode;
     int                 clamp_read_color;
     namestack_t         namestack;
@@ -131,7 +132,7 @@ typedef struct glstate_s {
     GLenum              blenddfactoralpha;
     GLenum              blendeqrgb;
     GLenum              blendeqalpha;
-} glstate_t;
+}; // glstate_t defined in oldprogram.h
 
 
 #endif // _GL4ES_GLSTATE_H_

--- a/src/gl/init.c
+++ b/src/gl/init.c
@@ -14,12 +14,7 @@
 #include "debug.h"
 #include "loader.h"
 #include "logs.h"
-
-#define fpe_state_t struct fpe_state_s
-#define kh_fpecachelist_t struct kh_fpecachelist_s
 #include "fpe_cache.h"
-#undef fpe_fpe_t
-#undef kh_fpecachelist_t
 #include "init.h"
 #include "envvars.h"
 #if defined(__EMSCRIPTEN__) || defined(__APPLE__)
@@ -127,15 +122,13 @@ void initialize_gl4es() {
     env(LIBGL_STACKTRACE, globals4es.stacktrace, "stacktrace will be printed on crash");
 
     const int LIBGL_FB_ENV_VAR = 
-	    ReturnEnvVarInt("LIBGL_FB");
-	const int LIBGL_FB_VALUE = 
 #       ifndef LIBGL_FB
-        LIBGL_FB_ENV_VAR
+        ReturnEnvVarInt("LIBGL_FB")
 #       else
-        0 == LIBGL_FB_ENV_VAR ? LIBGL_FB : 0
+        ReturnEnvVarIntDef("LIBGL_FB", LIBGL_FB)
 #       endif
     ;
-    switch(LIBGL_FB_VALUE) {
+    switch(LIBGL_FB_ENV_VAR) {
         case 1:
         SHUT_LOGD("framebuffer output enabled\n");
         globals4es.usefb = 1;

--- a/src/gl/oldprogram.c
+++ b/src/gl/oldprogram.c
@@ -1,13 +1,16 @@
+
+#include "oldprogram.h"
+
 #include "debug.h"
 #include "fpe.h"
 #include "gl4es.h"
 #include "glstate.h"
 #include "loader.h"
-#include "oldprogram.h"
 #include "shaderconv.h"
 #include "vertexattrib.h"
 #include "arbconverter.h"
 #include "debug.h"
+
 
 //#define DEBUG
 #ifdef DEBUG
@@ -20,7 +23,9 @@
 // the core of this is a conversion between ARB ASM-like syntax to GLSL, then using regular functions
 // Note that a program in this context is in fact a shader in ARB_vertex_shader (and GLSL) extension
 
+#define kh_oldprograms_t kh_oldprograms_s
 KHASH_MAP_INIT_INT(oldprograms, oldprogram_t *);
+#undef kh_oldprograms_t
 
 void freeOldProgram(oldprogram_t* old)
 {

--- a/src/gl/program.h
+++ b/src/gl/program.h
@@ -16,8 +16,10 @@ typedef struct {
 } attribloc_t;
 KHASH_MAP_DECLARE_INT(attribloclist, attribloc_t *);
 
+#ifndef _GL4ES_OLD_PROGRAM_H_
 typedef struct shader_s             shader_t;
-typedef struct shaderconv_need_s    shaderconv_need_t;
+#endif
+//typedef struct shaderconv_need_s    shaderconv_need_t;
 
 typedef enum {
     MAT_MV = 0,
@@ -210,8 +212,8 @@ typedef struct {
     int             attach_cap;
     int             attach_size;
     GLuint          *attach;
-    shader_t        *last_vert;
-    shader_t        *last_frag;
+    struct shader_s        *last_vert;
+    struct shader_s        *last_frag;
     int             default_vertex;
     int             default_fragment;
     shaderconv_need_t *default_need;    // filled only if default_vertex or default_fragment is used

--- a/src/gl/shader.h
+++ b/src/gl/shader.h
@@ -3,7 +3,11 @@
 
 #include "khash.h"
 #include "gles.h"
+
+#define  shaderconv_need_t struct shaderconv_need_s
 #include "oldprogram.h"
+#undef shaderconv_need_t
+
 #include <stdint.h>
 
 typedef struct shaderconv_need_s {
@@ -20,20 +24,20 @@ typedef struct shaderconv_need_s {
     uint32_t    need_texs;          // flags of what tex is needed
 } shaderconv_need_t;
 
-typedef struct shader_s {
+struct shader_s {
     GLuint          id;     // internal id of the shader
     GLenum          type;   // type of the shader (GL_VERTEX or GL_FRAGMENT)
     int             attached; // number of time the shader is attached
     int             deleted;// flagged for deletion
     int             compiled;// flag if compiled
-    oldprogram_t   *old;     // in case the shader is an old ARB ASM-like program
+    struct oldprogram_s   *old;     // in case the shader is an old ARB ASM-like program
     char*           source; // original source of the shader (or converted if coming from "old")
     char*           converted;  // converted source (or null if nothing)
     // shaderconv
     shaderconv_need_t  need;    // the varying need / provide of the shader
-} shader_t;
+}; // shader_t defined in oldprogram.h
 
-KHASH_MAP_DECLARE_INT(shaderlist, shader_t *);
+KHASH_MAP_DECLARE_INT(shaderlist, struct shader_s *);
 
 GLuint APIENTRY_GL4ES gl4es_glCreateShader(GLenum shaderType);
 void APIENTRY_GL4ES gl4es_glDeleteShader(GLuint shader);
@@ -50,14 +54,14 @@ void APIENTRY_GL4ES gl4es_glReleaseShaderCompiler(void);
 void accumShaderNeeds(GLuint shader, shaderconv_need_t *need);
 int isShaderCompatible(GLuint shader, shaderconv_need_t *need);
 void redoShader(GLuint shader, shaderconv_need_t *need);
-shader_t *getShader(GLuint shader);
+struct shader_s*getShader(GLuint shader);
 
 #define CHECK_SHADER(type, shader) \
     if(!shader) { \
         noerrorShim(); \
         return (type)0; \
     } \
-    shader_t *glshader = NULL; \
+    struct shader_s *glshader = NULL; \
     khint_t k_##shader; \
     { \
         khash_t(shaderlist) *shaders = glstate->glsl->shaders; \


### PR DESCRIPTION
* Moved header order
* Add local define guards for headers to avoid C99 typedef redefinition error
* tabs->spaces
* Add EGL support for QNX NTO platform
* glTexParameteri calls fixed to use gl4es wrapper