### PR TITLE
[FIX] fix array copying in gl4es_glMultiDrawElements

### DIFF
--- a/src/gl/drawing.c
+++ b/src/gl/drawing.c
@@ -937,14 +937,29 @@ void APIENTRY_GL4ES gl4es_glMultiDrawElements( GLenum mode, GLsizei *counts, GLe
             (!compiling && !intercept && type==GL_UNSIGNED_INT && hardext.elementuint)
             );
         if(need_free) {
-            sindices = copy_gl_array((glstate->vao->elements)?(void*)((char*)glstate->vao->elements->data + (uintptr_t)indices):indices,
-                type, 1, 0, GL_UNSIGNED_SHORT, 1, 0, count, NULL);
-            old_index = wantBufferIndex(0);
+              GLvoid *src;
+              if (glstate->vao->elements) {
+                  src = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices;
+              } else {
+                  src = (GLvoid *) indices[i];
+              }
+              sindices = copy_gl_array(src, type, 1, 0, GL_UNSIGNED_SHORT, 1, 0, count, NULL);  
+          old_index = wantBufferIndex(0);
         } else {
-            if(type==GL_UNSIGNED_INT)
-                iindices = (glstate->vao->elements)?((void*)((char*)glstate->vao->elements->data + (uintptr_t)indices)):(GLvoid*)indices;
-            else
-                sindices = (glstate->vao->elements)?((void*)((char*)glstate->vao->elements->data + (uintptr_t)indices)):(GLvoid*)indices;
+              if(type==GL_UNSIGNED_INT) {
+                  if (glstate->vao->elements) {
+                      iindices = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices;
+                  } else {
+                      iindices = (GLuint *) indices[i];
+                  }
+              }
+              else {
+                  if (glstate->vao->elements) {
+                      sindices = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices;
+                  } else {
+                      sindices = (GLushort *) indices[i];
+                  }
+              }
         }
 
         if (compiling) {


### PR DESCRIPTION
I run test `gl-1.4-dlist-multidrawarrays from piglit package (https://piglit.freedesktop.org/).

The test crashed with SIGSEV.
Back Trace:
```
Program terminated with signal SIGSEGV, Segmentation fault.                                                                                                     
#0  0x00007f07ba11f419 in copy_gl_array_texcoord (src=0x56259ad6a080 <verts>, from=5126, width=2, stride=8, to_width=4, skip=0,                                 count=60812, dst=0x5625b4482c40) at ./src/gl/array.c:101                                                                       
101                     out[j] = input[j];                                      
[Current thread is 1 (Thread 0x7f07b9826680 (LWP 114772))]                      
(gdb) bt                                
#0  0x00007f07ba11f419 in copy_gl_array_texcoord (src=0x56259ad6a080 <verts>, from=5126, width=2, stride=8, to_width=4, skip=0, count=60812, dst=0x5625b4482c40)    
#1  0x00007f07ba126812 in copy_gl_pointer_tex (ptr=0x5625b4134f98, width=4, skip=0, count=60812)                                                            
#2  0x00007f07ba13a6e2 in arrays_to_renderlist (list=0x5625b40a8f00, mode=6, skip=0, count=60812)                                                           
#3  0x00007f07ba13f0ad in gl4es_glMultiDrawElements (mode=6, counts=0x7ffeed8b08c4, type=5123, indices=0x7ffeed8b08c8, primcount=1)
#4  0x00007f07b9ee11fd in stub_glMultiDrawElements (mode=6, count=0x7ffeed8b08c4, type=5123, indices=0x7ffeed8b08c8, drawcount=1)                           
#5  0x000056259ad6957a in test_MultiDrawElements (dlmode=4864)                  
#6  0x000056259ad697be in piglit_display () at /home/funch0za/dev/GL4ES/piglit/tests/spec/gl-1.4/dlist-multidrawarrays.c:191                                    
#7  0x00007f07b9f4c422 in run_test (pgl_fw=0x7f07ba0140f8 <gl_fw>, argc=1, argv=0x7ffeed8b0b08)                                                                 
#8  0x00007f07b9f3c2cd in piglit_gl_test_run (argc=1, argv=0x7ffeed8b0b08, config=0x7ffeed8b0990)                                                               
#9  0x000056259ad69240 in main (argc=1, argv=0x7ffeed8b0b08)
```

I found that the `gl4es_glMultiDrawElements` function (in cycle) incorrectly copies the elements of a one-dimensional array to a two-dimensional one.
This change is enough:
``` diff
--- a/src/gl/drawing.c
+++ b/src/gl/drawing.c
@@ -937,14 +937,14 @@ void APIENTRY_GL4ES gl4es_glMultiDrawElements( GLenum mode, GLsizei *counts, GLe
             (!compiling && !intercept && type==GL_UNSIGNED_INT && hardext.elementuint)
             );
         if(need_free) {
-            sindices = copy_gl_array((glstate->vao->elements)?(void*)((char*)glstate->vao->elements->data + (uintptr_t)indices):indices,
+            sindices = copy_gl_array((glstate->vao->elements)?(void*)((char*)glstate->vao->elements->data + (uintptr_t)indices):indices[i],
                 type, 1, 0, GL_UNSIGNED_SHORT, 1, 0, count, NULL);
             old_index = wantBufferIndex(0);
         } else {
             if(type==GL_UNSIGNED_INT)
-                iindices = (glstate->vao->elements)?((void*)((char*)glstate->vao->elements->data + (uintptr_t)indices)):(GLvoid*)indices;
+                iindices = (glstate->vao->elements)?((void*)((char*)glstate->vao->elements->data + (uintptr_t)indices)):(GLvoid*)indices[i];
             else
-                sindices = (glstate->vao->elements)?((void*)((char*)glstate->vao->elements->data + (uintptr_t)indices)):(GLvoid*)indices;
+                sindices = (glstate->vao->elements)?((void*)((char*)glstate->vao->elements->data + (uintptr_t)indices)):(GLvoid*)indices[i];
         }
 
         if (compiling) {
```
But I rewrote ternary operator to simply `if` in my commit because it helped me with debugging. This might be a better alternative.

This patch fixes crash. Test has ended with the result `pass`:
```
PIGLIT: {"result": "pass" }
```