### PR TITLE
[FIX] multiple fixes regarding gl4es_glMultiDraw*

### DIFF
--- a/src/gl/drawing.c
+++ b/src/gl/drawing.c
@@ -939,7 +939,7 @@ void APIENTRY_GL4ES gl4es_glMultiDrawElements( GLenum mode, GLsizei *counts, GLe
         if(need_free) {
               GLvoid *src;
               if (glstate->vao->elements) {
-                  src = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices;
+                  src = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices[i];
               } else {
                   src = (GLvoid *) indices[i];
               }
@@ -948,14 +948,14 @@ void APIENTRY_GL4ES gl4es_glMultiDrawElements( GLenum mode, GLsizei *counts, GLe
         } else {
               if(type==GL_UNSIGNED_INT) {
                   if (glstate->vao->elements) {
-                      iindices = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices;
+                      iindices = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices[i];
                   } else {
                       iindices = (GLuint *) indices[i];
                   }
               }
               else {
                   if (glstate->vao->elements) {
-                      sindices = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices;
+                      sindices = (void*)(char*)glstate->vao->elements->data + (uintptr_t)indices[i];
                   } else {
                       sindices = (GLushort *) indices[i];
                   }


### PR DESCRIPTION
In commit `5957f59`:
There's already a loop at `drawing.c:803`:
```
for (int i=0; i<primcount; i++) {
```
The loop at `drawing.c:860` still uses `i` as loop index, which shadows the other `i` at line 803 and could cause a havoc. Now using `k` instead.

In commit `1a8ccc8`:
Probably a contiunation of PR #496 , which properly handles `indices` as offsets into EBO, when an EBO is bound (rather than the case of using client data directly)