### PR TITLE
src/cmake: Use DESTINATION compatible with prefixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -225,10 +225,10 @@ else()
     endif()
     install(TARGETS GL
       LIBRARY
-      DESTINATION "/usr/lib/gl4es/"
+      DESTINATION "usr/lib/gl4es/"
     )
     install(FILES "../include/gl4esinit.h" "../include/gl4eshint.h"
-      DESTINATION "/usr/include/gl4es/"
+      DESTINATION "usr/include/gl4es/"
     )
 endif()
 


### PR DESCRIPTION
Allows installation in various package formats, like Snaps. As seen on hybris-2404.