### PR TITLE
src/gl: force highp on texcoord varying to avoid precision loss on Adreno

### DIFF
--- a/src/gl/fpe_shader.c
+++ b/src/gl/fpe_shader.c
@@ -352,7 +352,7 @@ const char* const* fpe_VertexShader(shaderconv_need_t* need, fpe_state_t *state)
         if(need)
             t = (need->need_texs&(1<<i))?1:0;
         if(t) {
-            sprintf(buff, "varying %s _gl4es_TexCoord_%d;\n", texvecsize[t-1], i);
+            sprintf(buff, "varying highp %s _gl4es_TexCoord_%d;\n", texvecsize[t-1], i);
             ShadAppend(buff);
             headers++;
             if(state->texture[i].texmat) {
@@ -913,7 +913,7 @@ const char* const* fpe_FragmentShader(shaderconv_need_t* need, fpe_state_t *stat
             if(t && !need->need_texs&(1<<i))
                 t = 0;
         if(t) {
-            sprintf(buff, "varying %s _gl4es_TexCoord_%d;\n", texvecsize[t-1], i);
+            sprintf(buff, "varying highp %s _gl4es_TexCoord_%d;\n", texvecsize[t-1], i);
             ShadAppend(buff);
             sprintf(buff, "uniform %s _gl4es_TexSampler_%d;\n", texsampler[t-1], i);
             ShadAppend(buff);

--- a/src/gl/shaderconv.c
+++ b/src/gl/shaderconv.c
@@ -249,10 +249,10 @@ static const char* gl4es_backSecondaryColorSource =
 "varying lowp vec4 _gl4es_BackSecondaryColor;\n";
 
 static const char* gl4es_texcoordSource =
-"varying mediump vec4 _gl4es_TexCoord[%d];\n";
+"varying highp vec4 _gl4es_TexCoord[%d];\n";
 
 static const char* gl4es_texcoordSourceAlt =
-"varying mediump vec4 _gl4es_TexCoord_%d;\n";
+"varying highp vec4 _gl4es_TexCoord_%d;\n";
 
 static const char* gl4es_fogcoordSource =
 "varying mediump float _gl4es_FogFragCoord;\n";


### PR DESCRIPTION
Seems to be happening on wide range of Adreno GPUs as reported in Xash3D FWGS issue: https://github.com/FWGS/xash3d-fwgs/issues/1627

Before:
<details>
<img width="2340" height="1080" alt="Screenshot_20260521-003608" src="https://github.com/user-attachments/assets/c38715d5-2c37-4c9c-a655-4049830e2f2a" />

</details>

After:
<details>
<img width="2340" height="1080" alt="Screenshot_20260521-003136" src="https://github.com/user-attachments/assets/78cc313e-e9ae-4fb9-b29e-9b16681d10da" />

</details>