### PR TITLE
src/glx: Use Android EGL platform on libhybris

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(BCMHOST "Set to ON if targeting an RPi(2) device" ${BCMHOST})
 option(ODROID "Set to ON if targeting an ODroid device" ${ODROID})
 option(GOA_CLONE "Set to ON if targeting GO Advance clones, like RG351p/v, Gameforce Chi, RGB10..." ${GOA_CLONE})
 option(ANDROID "Set to ON if targeting an Android device" ${ANDROID})
+option(HYBRIS "Set to ON if targeting Android drivers on GNU/Linux" ${HYBRIS})
 option(CHIP "Set to ON if targeting an C.H.I.P. device" ${CHIP})
 option(AMIGAOS4 "Set to ON if targeting an AmigaOS4/Warp3D platform (activate NOEGL and NOX11)" ${AMIGAOS4})
 option(NOX11 "Set to ON to not use X11 (creation of context has to be done outside gl4es)" ${NOX11})
@@ -119,6 +120,12 @@ endif()
 if(USE_ANDROID_LOG)
     add_definitions(-DUSE_ANDROID_LOG)
     find_library(log-lib log)
+endif()
+
+# Android drivers on GNU/Linux aka "libhybris"
+if (HYBRIS)
+    add_definitions(-DHYBRIS)
+    add_definitions(-DNO_GBM -DDEFAULT_ES=2)
 endif()
 
 #PocketCHIP

--- a/src/glx/glx.c
+++ b/src/glx/glx.c
@@ -377,6 +377,7 @@ static int get_config_default(Display *display, int attribute, int *value) {
 
 static void init_display(Display *display) {
     LOAD_EGL(eglGetDisplay);
+    LOAD_EGL(eglGetPlatformDisplay);
 
     if (! g_display) {
         g_display = display;//XOpenDisplay(NULL);
@@ -384,6 +385,12 @@ static void init_display(Display *display) {
     if(globals4es.usegbm) {
         eglDisplay = OpenGBMDisplay(display);
     }
+
+#ifdef HYBRIS
+    EGLint attribs[] = { EGL_NONE };
+    eglDisplay = egl_eglGetPlatformDisplay(EGL_PLATFORM_ANDROID_KHR, EGL_DEFAULT_DISPLAY, attribs);
+#endif
+
     if(!eglDisplay) {
         if (globals4es.usefb || globals4es.usepbuffer) {
             eglDisplay = egl_eglGetDisplay(EGL_DEFAULT_DISPLAY);

--- a/src/glx/hardext.c
+++ b/src/glx/hardext.c
@@ -141,6 +141,7 @@ void GetHardwareExtensions(int notest)
     LOAD_EGL(eglBindAPI);
     LOAD_EGL(eglInitialize);
     LOAD_EGL(eglGetDisplay);
+    LOAD_EGL(eglGetPlatformDisplay);
     LOAD_EGL(eglCreatePbufferSurface);
     LOAD_EGL(eglDestroySurface);
     LOAD_EGL(eglDestroyContext);
@@ -203,7 +204,14 @@ void GetHardwareExtensions(int notest)
     }
     else
 #endif
+#ifdef HYBRIS
+    {
+        EGLint attribs[] = { EGL_NONE };
+        eglDisplay = egl_eglGetPlatformDisplay(EGL_PLATFORM_ANDROID_KHR, EGL_DEFAULT_DISPLAY, attribs);
+    }
+#else
         eglDisplay = egl_eglGetDisplay(EGL_DEFAULT_DISPLAY);
+#endif
 
     egl_eglBindAPI(EGL_OPENGL_ES_API);
     if (egl_eglInitialize(eglDisplay, NULL, NULL) != EGL_TRUE) {


### PR DESCRIPTION
libhybris EGL has support for multiple EGL platforms, either "wayland" for supporting the Wayland protocol, or "null" for connecting to Android's single display as a passthrough. In order for gl4es to default to the required "null" platform get the Android-specific platform display.

This is a build-time flag since just calling "eglGetDisplay" might initialize libhybris' windowing system to Wayland, so we need to be explicit in what platform we choose.

This allows GL4ES to initialize without conflicting with a default "wayland" platform.